### PR TITLE
Section 2.1: Reset Cache write-safety + sync hardening

### DIFF
--- a/LocationApp/Location Cache/Cache.swift
+++ b/LocationApp/Location Cache/Cache.swift
@@ -14,7 +14,23 @@ class Cache: Codable {
     var locations = [LocationRecordCacheItem]()
     var changes = [LocationRecordCacheItem]()
     var settings = Settings()
-    
+
+    // Transient recordName -> index map. Not persisted; rebuilt after load().
+    // Without it, add() does an O(n) firstIndex(where:) per record, which makes
+    // initial sync of N records O(N^2).
+    private var locationIndex: [String: Int] = [:]
+
+    private enum CodingKeys: String, CodingKey {
+        case version, user, locations, changes, settings
+    }
+
+    private func rebuildLocationIndex() {
+        locationIndex.removeAll(keepingCapacity: true)
+        for (i, loc) in locations.enumerated() {
+            if let name = loc.recordName { locationIndex[name] = i }
+        }
+    }
+
     static func load() -> Cache? {
         if Cache.locationRecordCacheFileExists() {
             let cacheFileURL = URL(fileURLWithPath: pathToCache())
@@ -27,16 +43,22 @@ class Cache: Codable {
                 print("Error decoding cache from data")
                 return nil
             }
+            locationsCache.rebuildLocationIndex()
             return locationsCache
         }
         return nil
     }
-    
+
     func add(_ item: LocationRecordCacheItem) {
-        if let index = locations.firstIndex(where: { l in l.recordName == item.recordName}) {
-            locations[index] = item
+        guard let name = item.recordName else {
+            locations.append(item)
+            return
+        }
+        if let i = locationIndex[name] {
+            locations[i] = item
         }
         else {
+            locationIndex[name] = locations.count
             locations.append(item)
         }
     }
@@ -53,6 +75,7 @@ class Cache: Codable {
     
     func clear() {
         locations.removeAll()
+        locationIndex.removeAll()
     }
     
     func save() {

--- a/LocationApp/Location Cache/Cache.swift
+++ b/LocationApp/Location Cache/Cache.swift
@@ -63,6 +63,13 @@ class Cache: Codable {
         }
     }
     
+    // O(1) lookup by recordName via the same transient index add() maintains.
+    // Lets callers check the cached state of a record without an O(n) scan.
+    func location(forRecordName name: String) -> LocationRecordCacheItem? {
+        guard let i = locationIndex[name] else { return nil }
+        return locations[i]
+    }
+
     func addChange(_ item: LocationRecordCacheItem) {
         item.setValue(user, forKey: "modifiedBy")
         if let index = changes.firstIndex(where: { l in l.recordName == item.recordName}) {

--- a/LocationApp/Location Cache/LocationRecordCacheItem.swift
+++ b/LocationApp/Location Cache/LocationRecordCacheItem.swift
@@ -170,7 +170,41 @@ class LocationRecordCacheItem: Codable, LocationRecordDelegate {
         // set the record name
         self.recordName = record.recordID.recordName
  }
-    
+
+    // Copy initializer. Produces a distinct instance with the same field values
+    // (including photo and recordName), tolerating nil optionals — unlike
+    // init?(withRecord:), which requires dosinumber/collectedFlag/cycleDate and
+    // would reject an undeployed location. The edit popup uses this to save a
+    // copy instead of mutating the cache's live record in place: that aliasing
+    // made LocationsCK.save's already-collected guard compare the record against
+    // itself and silently drop a genuine collect (QA-1 DEFECT-1).
+    init(copying other: LocationRecordCacheItem) {
+        QRCode = other.QRCode
+        latitude = other.latitude
+        longitude = other.longitude
+        locdescription = other.locdescription
+        active = other.active
+        dosinumber = other.dosinumber
+        collectedFlag = other.collectedFlag
+        cycleDate = other.cycleDate
+        mismatch = other.mismatch
+        moderator = other.moderator
+        creationDate = other.creationDate
+        createdDate = other.createdDate
+        modifiedDate = other.modifiedDate
+        modificationDate = other.modificationDate
+        recordName = other.recordName
+        modifiedBy = other.modifiedBy
+        reportGroup = other.reportGroup
+        hasPhoto = other.hasPhoto
+        photo = other.photo
+    }
+
+    // Convenience wrapper around init(copying:) for a distinct duplicate.
+    func copy() -> LocationRecordCacheItem {
+        return LocationRecordCacheItem(copying: self)
+    }
+
     // Subscript operator overload used to access properties.
     subscript(key: String) -> CKRecordValue? {
         get {

--- a/LocationApp/Location Cache/LocationRecordCacheItem.swift
+++ b/LocationApp/Location Cache/LocationRecordCacheItem.swift
@@ -65,6 +65,16 @@ class LocationRecordCacheItem: Codable, LocationRecordDelegate {
         case QRCode, latitude, longitude, locdescription, active, dosinumber, collectedFlag, cycleDate, mismatch, moderator, creationDate, createdDate, modifiedDate, modificationDate, recordName, modifiedBy, reportGroup, hasPhoto
     }
 
+    // Nil-safe ordering key for createdDate. CloudKit can return a nil
+    // createdDate for very old / partially-populated records; the UI sorts
+    // newest-first and used to force-unwrap createdDate, which crashed on
+    // those records. Treating nil as the oldest possible date keeps the same
+    // newest-first ordering (nil lands last) without the force-unwrap — the
+    // sort sibling of the skip-nil Dosimeter init (commit 931ccc2).
+    var createdDateForSort: Date {
+        return createdDate ?? .distantPast
+    }
+
     // Location Record Metadata
     
     // Initialize with a CloudKit Record

--- a/LocationApp/Location Cache/Locations.swift
+++ b/LocationApp/Location Cache/Locations.swift
@@ -160,18 +160,24 @@ class LocationsCK : Locations, SettingsService {
         }
     }
     
-    fileprivate func uploadChanges(_ records: [CKRecord]) {
+    fileprivate func uploadChanges(_ items: [LocationRecordCacheItem]) {
         let size = 200
         var page = 1
         var total = 0
-        print("Prepare to save \(records.count) records.")
-        while (records.count > total) {
-            let count = records.count >= page * size ? size : records.count - total
-            let slice = Array(records[total...total + count - 1])
+        print("Prepare to save \(items.count) records.")
+        while (items.count > total) {
+            let count = items.count >= page * size ? size : items.count - total
+            let slice = Array(items[total...total + count - 1])
             total = page * size
             page += 1
-   
-            let operation = CKModifyRecordsOperation(recordsToSave: slice, recordIDsToDelete: nil)
+
+            // Build the CKRecords for this page. Days 5-7 replace this straight
+            // item.to() conversion with a fetch-merge against the current server
+            // records; for now this is a behavior-preserving move of the
+            // conversion out of saveChanges() so the paging loop owns it.
+            let recordsToSave = slice.map { $0.to() }
+
+            let operation = CKModifyRecordsOperation(recordsToSave: recordsToSave, recordIDsToDelete: nil)
             operation.savePolicy = .allKeys
             operation.modifyRecordsResultBlock = { result in
                 switch result {
@@ -189,12 +195,8 @@ class LocationsCK : Locations, SettingsService {
             DispatchQueue.global(qos: .background).async {
                 self.semaphore.wait()
                 if (!self.cache!.changes.isEmpty) {
-                    var records = [CKRecord]()
-                    for item in self.cache!.changes {
-                        records.append(item.to())
-                    }
-                    
-                    self.uploadChanges(records)
+                    let items = Array(self.cache!.changes)
+                    self.uploadChanges(items)
                     self.cache?.changes.removeAll()
                     self.cache?.save()
                     self.semaphore.signal()

--- a/LocationApp/Location Cache/Locations.swift
+++ b/LocationApp/Location Cache/Locations.swift
@@ -161,7 +161,7 @@ class LocationsCK : Locations, SettingsService {
     }
     
     fileprivate func uploadChanges(_ records: [CKRecord]) {
-        let size = 400
+        let size = 200
         var page = 1
         var total = 0
         print("Prepare to save \(records.count) records.")

--- a/LocationApp/Location Cache/Locations.swift
+++ b/LocationApp/Location Cache/Locations.swift
@@ -160,10 +160,23 @@ class LocationsCK : Locations, SettingsService {
         }
     }
     
-    // Fetches the current server-side records for the given IDs. Days 6-7 consume
-    // the returned dictionary to skip already-collected records and to apply local
-    // fields onto a fetched base for .ifServerRecordUnchanged saves. Day 5 wires
-    // the fetch into uploadChanges but leaves save semantics unchanged.
+    // Pure decision used by uploadChanges: skip saving when the server already
+    // shows the record collected on the same cycle. The server is the source of
+    // truth — overwriting a server-side collected record with a stale local one
+    // would silently revert a completed field action.
+    // Internal (not private) so LocationAppTests can drive the decision matrix
+    // offline; same exception precedent as Day 3's bulkSyncDesiredKeys.
+    internal static func shouldSkipSave(item: LocationRecordCacheItem, serverRecord: CKRecord?) -> Bool {
+        guard let serverRecord = serverRecord else { return false }
+        guard let serverCollected = serverRecord["collectedFlag"] as? Int64,
+              let serverCycle = serverRecord["cycleDate"] as? String else { return false }
+        return serverCollected == 1 && serverCycle == item.cycleDate
+    }
+
+    // Fetches the current server-side records for the given IDs. Day 6 uses
+    // the returned dictionary to skip already-collected records; Day 7 will
+    // additionally apply local fields onto the fetched base for
+    // .ifServerRecordUnchanged saves.
     fileprivate func fetchServerRecords(_ ids: [CKRecord.ID]) -> [CKRecord.ID: CKRecord] {
         guard !ids.isEmpty else { return [:] }
         var fetched: [CKRecord.ID: CKRecord] = [:]
@@ -193,20 +206,34 @@ class LocationsCK : Locations, SettingsService {
             total = page * size
             page += 1
 
-            // Fetch the current server records for this page. Day 5 logs the
-            // result; Days 6-7 use it to skip already-collected records and to
-            // apply local fields onto the fetched base for conflict-safe saves.
             let ids = slice.compactMap { $0.recordName }.map { CKRecord.ID(recordName: $0) }
             let serverRecords = fetchServerRecords(ids)
             print("Fetched \(serverRecords.count) server records for page of \(slice.count).")
 
-            let recordsToSave = slice.map { $0.to() }
+            var recordsToSave: [CKRecord] = []
+            for item in slice {
+                guard let recordName = item.recordName else { continue }
+                let id = CKRecord.ID(recordName: recordName)
+                if LocationsCK.shouldSkipSave(item: item, serverRecord: serverRecords[id]) {
+                    print("Skipping save for \(recordName): already collected on server for cycle \(item.cycleDate ?? "nil")")
+                    continue
+                }
+                recordsToSave.append(item.to())
+            }
+
+            if recordsToSave.isEmpty { continue }
 
             let operation = CKModifyRecordsOperation(recordsToSave: recordsToSave, recordIDsToDelete: nil)
             operation.savePolicy = .allKeys
+            operation.qualityOfService = .userInitiated
+            operation.perRecordSaveBlock = { id, result in
+                if case .failure(let error) = result {
+                    print("Per-record save failed for \(id.recordName): \(error.localizedDescription)")
+                }
+            }
             operation.modifyRecordsResultBlock = { result in
                 switch result {
-                    case .success : print("Saved locations.")
+                    case .success : print("Saved \(recordsToSave.count) location records.")
                     case .failure(let error) :print(error.localizedDescription)
                 }
             }

--- a/LocationApp/Location Cache/Locations.swift
+++ b/LocationApp/Location Cache/Locations.swift
@@ -262,10 +262,22 @@ class LocationsCK : Locations, SettingsService {
         })
     }
     
+    // Fields LocationRecordCacheItem(withRecord:) reads, minus the heavy CKAsset.
+    // Photos are fetched lazily via Locations.fetch(id:) when the user opens the
+    // detail or photo view, so excluding "photo" from bulk sync drops the biggest
+    // per-record payload from the initial download.
+    // Internal (not private) so unit tests can verify the field set.
+    static let bulkSyncDesiredKeys: [String] = [
+        "QRCode", "latitude", "longitude", "locdescription", "active",
+        "dosinumber", "collectedFlag", "cycleDate", "mismatch", "moderator",
+        "createdDate", "modifiedDate", "modifiedBy", "reportGroup", "hasPhoto"
+    ]
+
     private func add(_ query : CKQueryOperation, loaded: @escaping ((Int) -> Void), completionHandler: @escaping ([LocationRecordDelegate], Bool?, Error?,@escaping ((Int) -> Void)) -> Void) {
         var result: [LocationRecordDelegate] = []
         let operation = query
         operation.resultsLimit = 500
+        operation.desiredKeys = LocationsCK.bulkSyncDesiredKeys
         operation.recordMatchedBlock = { _, res in
             switch res {
                 case .success(let record) : result.append(record)

--- a/LocationApp/Location Cache/Locations.swift
+++ b/LocationApp/Location Cache/Locations.swift
@@ -173,10 +173,11 @@ class LocationsCK : Locations, SettingsService {
         return serverCollected == 1 && serverCycle == item.cycleDate
     }
 
-    // Fetches the current server-side records for the given IDs. Day 6 uses
-    // the returned dictionary to skip already-collected records; Day 7 will
-    // additionally apply local fields onto the fetched base for
-    // .ifServerRecordUnchanged saves.
+    // Fetches the current server-side records for the given IDs. uploadChanges
+    // uses the returned dictionary to (1) skip records the server already shows
+    // collected on the same cycle and (2) apply local fields onto the fetched
+    // base so .ifServerRecordUnchanged can detect mid-flight conflicts via the
+    // record's recordChangeTag.
     fileprivate func fetchServerRecords(_ ids: [CKRecord.ID]) -> [CKRecord.ID: CKRecord] {
         guard !ids.isEmpty else { return [:] }
         var fetched: [CKRecord.ID: CKRecord] = [:]
@@ -218,13 +219,24 @@ class LocationsCK : Locations, SettingsService {
                     print("Skipping save for \(recordName): already collected on server for cycle \(item.cycleDate ?? "nil")")
                     continue
                 }
-                recordsToSave.append(item.to())
+                if let serverRecord = serverRecords[id] {
+                    // Apply local fields onto the fetched record so the save carries
+                    // the server's recordChangeTag. .ifServerRecordUnchanged then
+                    // rejects this write if another device modified the record
+                    // between our fetch and save — the core of the concurrent-user fix.
+                    item.update(newRecord: serverRecord)
+                    recordsToSave.append(serverRecord)
+                }
+                else {
+                    // No record on server yet — first-time upload. No tag to preserve.
+                    recordsToSave.append(item.to())
+                }
             }
 
             if recordsToSave.isEmpty { continue }
 
             let operation = CKModifyRecordsOperation(recordsToSave: recordsToSave, recordIDsToDelete: nil)
-            operation.savePolicy = .allKeys
+            operation.savePolicy = .ifServerRecordUnchanged
             operation.qualityOfService = .userInitiated
             operation.perRecordSaveBlock = { id, result in
                 if case .failure(let error) = result {

--- a/LocationApp/Location Cache/Locations.swift
+++ b/LocationApp/Location Cache/Locations.swift
@@ -28,6 +28,8 @@ protocol Locations {
     func reset(_ loaded: @escaping  ((Int) -> Void))
     
     func fetch(id: String, completionHandler: @escaping (LocationRecordCacheItem?, Error?) -> Void)
+
+    var pendingChangeCount: Int { get }
 }
 
 class LocationsCK : Locations, SettingsService {
@@ -161,7 +163,17 @@ class LocationsCK : Locations, SettingsService {
         semaphore.signal()
         self.synchronize(loaded: loaded)
     }
-    
+
+    // Number of edits queued for upload but not yet synced. Read under the same
+    // semaphore every other cache mutation uses, so the count is consistent with
+    // a concurrent save/sync rather than a half-applied batch. Day 10's Reset Cache
+    // confirmation surfaces this to the user before clearing the cache.
+    var pendingChangeCount: Int {
+        semaphore.wait()
+        defer { semaphore.signal() }
+        return cache?.changes.count ?? 0
+    }
+
     private func reachable(_ : Reachability) {
         DispatchQueue.global(qos: .background).async {
             self.semaphore.wait()

--- a/LocationApp/Location Cache/Locations.swift
+++ b/LocationApp/Location Cache/Locations.swift
@@ -124,14 +124,31 @@ class LocationsCK : Locations, SettingsService {
     func save(items: [LocationRecordCacheItem], completionHandler: (() -> Void)?) {
         DispatchQueue.global(qos: .background).async {
             self.semaphore.wait()
+            var queued = 0
             for item in items {
+                // Local guardrail: drop the edit if our own cache already shows this
+                // record collected for the same cycle. Catching it at the local-write
+                // boundary keeps a stale edit from ever being queued for upload — the
+                // local complement to uploadChanges' server-side skip (shouldSkipSave),
+                // which guards the same invariant against changes made on another
+                // device. See shouldSkipLocalSave for the decision.
+                let cached = item.recordName.flatMap { self.cache?.location(forRecordName: $0) }
+                if LocationsCK.shouldSkipLocalSave(item: item, cached: cached) {
+                    print("Skipping save for \(item.recordName ?? "?"): local cache shows collected for cycle \(cached?.cycleDate ?? "nil")")
+                    continue
+                }
                 self.reportGroupUpdate(item)
                 self.cache?.add(item)
                 self.cache?.addChange(item)
+                queued += 1
             }
-            self.cache?.save()
+            if queued > 0 {
+                self.cache?.save()
+            }
             self.semaphore.signal()
-            self.saveChanges()
+            if queued > 0 {
+                self.saveChanges()
+            }
             DispatchQueue.main.async {
                 completionHandler?()
             }
@@ -171,6 +188,19 @@ class LocationsCK : Locations, SettingsService {
         guard let serverCollected = serverRecord["collectedFlag"] as? Int64,
               let serverCycle = serverRecord["cycleDate"] as? String else { return false }
         return serverCollected == 1 && serverCycle == item.cycleDate
+    }
+
+    // Pure decision used by save(items:): the local complement to shouldSkipSave.
+    // Skip queuing an edit when our own cache already shows the record collected on
+    // the same cycle — once collected for a cycle a record is meant to be immutable
+    // until the next cycle, so re-saving it would only queue a stale upload. `cached`
+    // is the existing cache entry for this recordName (nil if we've never seen it).
+    // Internal (not private) so LocationAppTests can drive the decision matrix
+    // offline; same exception precedent as Day 3's bulkSyncDesiredKeys.
+    internal static func shouldSkipLocalSave(item: LocationRecordCacheItem, cached: LocationRecordCacheItem?) -> Bool {
+        guard let cached = cached else { return false }
+        guard cached.collectedFlag == 1, let cachedCycle = cached.cycleDate else { return false }
+        return cachedCycle == item.cycleDate
     }
 
     // Fetches the current server-side records for the given IDs. uploadChanges

--- a/LocationApp/Location Cache/Locations.swift
+++ b/LocationApp/Location Cache/Locations.swift
@@ -160,6 +160,28 @@ class LocationsCK : Locations, SettingsService {
         }
     }
     
+    // Fetches the current server-side records for the given IDs. Days 6-7 consume
+    // the returned dictionary to skip already-collected records and to apply local
+    // fields onto a fetched base for .ifServerRecordUnchanged saves. Day 5 wires
+    // the fetch into uploadChanges but leaves save semantics unchanged.
+    fileprivate func fetchServerRecords(_ ids: [CKRecord.ID]) -> [CKRecord.ID: CKRecord] {
+        guard !ids.isEmpty else { return [:] }
+        var fetched: [CKRecord.ID: CKRecord] = [:]
+        let waitSemaphore = DispatchSemaphore(value: 0)
+        let fetchOp = CKFetchRecordsOperation(recordIDs: ids)
+        fetchOp.qualityOfService = .userInitiated
+        fetchOp.perRecordResultBlock = { id, result in
+            switch result {
+            case .success(let record): fetched[id] = record
+            case .failure(let error): print("Fetch failed for \(id.recordName): \(error.localizedDescription)")
+            }
+        }
+        fetchOp.fetchRecordsResultBlock = { _ in waitSemaphore.signal() }
+        self.database.add(fetchOp)
+        waitSemaphore.wait()
+        return fetched
+    }
+
     fileprivate func uploadChanges(_ items: [LocationRecordCacheItem]) {
         let size = 200
         var page = 1
@@ -171,10 +193,13 @@ class LocationsCK : Locations, SettingsService {
             total = page * size
             page += 1
 
-            // Build the CKRecords for this page. Days 5-7 replace this straight
-            // item.to() conversion with a fetch-merge against the current server
-            // records; for now this is a behavior-preserving move of the
-            // conversion out of saveChanges() so the paging loop owns it.
+            // Fetch the current server records for this page. Day 5 logs the
+            // result; Days 6-7 use it to skip already-collected records and to
+            // apply local fields onto the fetched base for conflict-safe saves.
+            let ids = slice.compactMap { $0.recordName }.map { CKRecord.ID(recordName: $0) }
+            let serverRecords = fetchServerRecords(ids)
+            print("Fetched \(serverRecords.count) server records for page of \(slice.count).")
+
             let recordsToSave = slice.map { $0.to() }
 
             let operation = CKModifyRecordsOperation(recordsToSave: recordsToSave, recordIDsToDelete: nil)

--- a/LocationApp/LocationApp.xcodeproj/project.pbxproj
+++ b/LocationApp/LocationApp.xcodeproj/project.pbxproj
@@ -737,7 +737,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.SLAC.LocationApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -760,7 +760,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.SLAC.LocationApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/LocationApp/LocationApp/Base.lproj/Main.storyboard
+++ b/LocationApp/LocationApp/Base.lproj/Main.storyboard
@@ -278,7 +278,7 @@
                                     <segue destination="BYZ-38-t0r" kind="presentation" id="cs9-V2-lMJ"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="May, 2023" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3FX-rC-9sw">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Build date" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3FX-rC-9sw">
                                 <rect key="frame" x="180.33333333333334" y="832" width="67.666666666666657" height="17"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -344,6 +344,7 @@
                     </view>
                     <connections>
                         <outlet property="activityIndicator" destination="12k-op-bR2" id="Xfh-4i-zsU"/>
+                        <outlet property="buildDateLabel" destination="3FX-rC-9sw" id="BDt-Lb-9sw"/>
                         <outlet property="button1" destination="P1C-rk-auY" id="9O8-Dx-vXv"/>
                         <outlet property="button2" destination="f4q-J5-UJn" id="iTU-a5-n1X"/>
                         <outlet property="button3" destination="iL3-Xk-1J0" id="GOc-1P-xTC"/>

--- a/LocationApp/LocationAppTests/LocationAppTests.swift
+++ b/LocationApp/LocationAppTests/LocationAppTests.swift
@@ -392,6 +392,30 @@ class LocationAppTests: XCTestCase {
         return record
     }
 
+    // copy() must produce a DISTINCT instance with the same field values, and
+    // mutating the copy must not touch the original. This is the invariant the
+    // edit popup relies on so LocationsCK.save's already-collected guard sees the
+    // record's true prior state instead of an in-place-mutated alias (QA-1 DEFECT-1):
+    // before the fix the popup edited the cached record in place, flipping
+    // collectedFlag to 1 before the guard ran, so a genuine collect was skipped.
+    func test_copy_isDistinctInstanceAndDoesNotAliasOriginal() throws {
+        let original = try makeItem(recordName: "R1", cycleDate: "1-1-2026")
+        original.collectedFlag = 0
+        original.dosinumber = "QA000000001"
+
+        let copy = original.copy()
+
+        XCTAssertFalse(copy === original, "copy must be a distinct instance")
+        XCTAssertEqual(copy.recordName, "R1")
+        XCTAssertEqual(copy.cycleDate, "1-1-2026")
+        XCTAssertEqual(copy.collectedFlag, 0)
+        XCTAssertEqual(copy.dosinumber, "QA000000001")
+
+        // Mutating the copy (as the popup does on a collect) must not leak back.
+        copy.collectedFlag = 1
+        XCTAssertEqual(original.collectedFlag, 0, "copy must not alias the original")
+    }
+
     private func makeItem(recordName: String?, locdescription: String = "test", hasPhoto: Bool = false, cycleDate: String? = nil, createdDate: Double? = nil) throws -> LocationRecordCacheItem {
         var fields: [String] = [
             "\"QRCode\": \"Q\"",

--- a/LocationApp/LocationAppTests/LocationAppTests.swift
+++ b/LocationApp/LocationAppTests/LocationAppTests.swift
@@ -260,6 +260,80 @@ class LocationAppTests: XCTestCase {
                        "Field values still flow from item onto the fetched record")
     }
 
+    // MARK: - shouldSkipLocalSave decision (Day 8)
+
+    // shouldSkipLocalSave is the local-write guardrail save(items:) consults before
+    // queuing an edit. It is the local mirror of shouldSkipSave: where shouldSkipSave
+    // trusts the fetched *server* record, this one trusts our own *cache* entry, so a
+    // record already known-collected for the current cycle never gets queued for
+    // upload in the first place.
+
+    func test_shouldSkipLocalSave_returnsFalseWhenNotCached() throws {
+        let item = try makeItem(recordName: "r1", cycleDate: "1-1-2026")
+
+        XCTAssertFalse(LocationsCK.shouldSkipLocalSave(item: item, cached: nil),
+                       "A record we've never cached can't be a stale re-collect; let the save proceed")
+    }
+
+    func test_shouldSkipLocalSave_returnsTrueWhenCachedCollectedOnSameCycle() throws {
+        let cached = try makeItem(recordName: "r1", cycleDate: "1-1-2026")
+        cached.collectedFlag = 1
+        let item = try makeItem(recordName: "r1", cycleDate: "1-1-2026")
+
+        XCTAssertTrue(LocationsCK.shouldSkipLocalSave(item: item, cached: cached),
+                      "A record our cache already shows collected this cycle is immutable until next cycle; drop the edit before it's queued")
+    }
+
+    func test_shouldSkipLocalSave_returnsFalseWhenCachedNotCollected() throws {
+        let cached = try makeItem(recordName: "r1", cycleDate: "1-1-2026")
+        cached.collectedFlag = 0
+        let item = try makeItem(recordName: "r1", cycleDate: "1-1-2026")
+
+        XCTAssertFalse(LocationsCK.shouldSkipLocalSave(item: item, cached: cached),
+                       "An uncollected cached record is exactly what this edit means to update; do not skip")
+    }
+
+    func test_shouldSkipLocalSave_returnsFalseWhenCachedCollectedOnPriorCycle() throws {
+        let cached = try makeItem(recordName: "r1", cycleDate: "7-1-2025")
+        cached.collectedFlag = 1
+        let item = try makeItem(recordName: "r1", cycleDate: "1-1-2026")
+
+        XCTAssertFalse(LocationsCK.shouldSkipLocalSave(item: item, cached: cached),
+                       "Collected-flag is per-cycle; a prior-cycle collection must not block this cycle's save")
+    }
+
+    func test_shouldSkipLocalSave_returnsFalseWhenCachedMissingCycle() throws {
+        let cached = try makeItem(recordName: "r1")
+        cached.collectedFlag = 1
+        let item = try makeItem(recordName: "r1", cycleDate: "1-1-2026")
+
+        XCTAssertFalse(LocationsCK.shouldSkipLocalSave(item: item, cached: cached),
+                       "Without a cached cycle we can't conclude same-cycle collection; do not skip")
+    }
+
+    // MARK: - Cache.location(forRecordName:) lookup (Day 8)
+
+    // The guardrail needs the current cache entry for a recordName without an O(n)
+    // scan; location(forRecordName:) reuses the same transient index add() maintains.
+
+    func test_cacheLocation_returnsAddedItem() throws {
+        let cache = Cache()
+        cache.add(try makeItem(recordName: "r1", locdescription: "north gate"))
+
+        XCTAssertEqual(cache.location(forRecordName: "r1")?.locdescription, "north gate")
+        XCTAssertNil(cache.location(forRecordName: "missing"),
+                     "Unknown recordName must return nil, not a neighbouring record")
+    }
+
+    func test_cacheLocation_reflectsUpsert() throws {
+        let cache = Cache()
+        cache.add(try makeItem(recordName: "r1", locdescription: "old"))
+        cache.add(try makeItem(recordName: "r1", locdescription: "new"))
+
+        XCTAssertEqual(cache.location(forRecordName: "r1")?.locdescription, "new",
+                       "add() upserts in place; the lookup must see the latest value at the indexed slot")
+    }
+
     // MARK: - Fixtures
 
     /// A Location CKRecord with every field `init?(withRecord:)` needs, minus the

--- a/LocationApp/LocationAppTests/LocationAppTests.swift
+++ b/LocationApp/LocationAppTests/LocationAppTests.swift
@@ -119,6 +119,39 @@ class LocationAppTests: XCTestCase {
                         "bulkSyncDesiredKeys must include every field init?(withRecord:) requires")
     }
 
+    // MARK: - uploadChanges item→record conversion (Day 4)
+
+    // Day 4 moved the item.to() conversion out of saveChanges() and into
+    // uploadChanges()'s paging loop (slice.map { $0.to() }). These lock down
+    // the conversion the loop now depends on; Days 5-7 build the fetch-merge
+    // on top of it.
+
+    func test_to_buildsLocationRecordWithMatchingRecordID() throws {
+        let record = try makeItem(recordName: "r1").to()
+
+        XCTAssertEqual(record.recordType, "Location")
+        XCTAssertEqual(record.recordID.recordName, "r1",
+                       "uploadChanges builds the CKRecord from the cache item; the recordID must round-trip the item's recordName so the save targets the correct server record")
+    }
+
+    func test_to_copiesScalarFieldsOntoRecord() throws {
+        let record = try makeItem(recordName: "r1", locdescription: "north gate").to()
+
+        XCTAssertEqual(record["locdescription"] as? String, "north gate")
+        XCTAssertEqual(record["QRCode"] as? String, "Q")
+        XCTAssertEqual(record["latitude"] as? String, "0")
+        XCTAssertEqual(record["longitude"] as? String, "0")
+        XCTAssertEqual(record["active"] as? Int64, 0)
+    }
+
+    func test_to_mapsHasPhotoBoolToRecordInt() throws {
+        let withPhoto = try makeItem(recordName: "r1", hasPhoto: true).to()
+        let withoutPhoto = try makeItem(recordName: "r2", hasPhoto: false).to()
+
+        XCTAssertEqual(withPhoto["hasPhoto"] as? Int, 1, "hasPhoto == true must serialize to 1")
+        XCTAssertEqual(withoutPhoto["hasPhoto"] as? Int, 0, "hasPhoto == false must serialize to 0")
+    }
+
     // MARK: - Fixtures
 
     /// A Location CKRecord with every field `init?(withRecord:)` needs, minus the
@@ -148,14 +181,14 @@ class LocationAppTests: XCTestCase {
         return record
     }
 
-    private func makeItem(recordName: String?, locdescription: String = "test") throws -> LocationRecordCacheItem {
+    private func makeItem(recordName: String?, locdescription: String = "test", hasPhoto: Bool = false) throws -> LocationRecordCacheItem {
         var fields: [String] = [
             "\"QRCode\": \"Q\"",
             "\"latitude\": \"0\"",
             "\"longitude\": \"0\"",
             "\"locdescription\": \"\(locdescription)\"",
             "\"active\": 0",
-            "\"hasPhoto\": false"
+            "\"hasPhoto\": \(hasPhoto)"
         ]
         if let recordName = recordName {
             fields.append("\"recordName\": \"\(recordName)\"")

--- a/LocationApp/LocationAppTests/LocationAppTests.swift
+++ b/LocationApp/LocationAppTests/LocationAppTests.swift
@@ -152,6 +152,51 @@ class LocationAppTests: XCTestCase {
         XCTAssertEqual(withoutPhoto["hasPhoto"] as? Int, 0, "hasPhoto == false must serialize to 0")
     }
 
+    // MARK: - shouldSkipSave decision (Day 6)
+
+    // shouldSkipSave is the pure decision uploadChanges consults inside its
+    // paging loop to skip records the server already shows as collected on the
+    // same cycle. The fetched-but-unused dictionary from Day 5 now drives this.
+
+    func test_shouldSkipSave_returnsFalseWhenServerRecordMissing() throws {
+        let item = try makeItem(recordName: "r1", cycleDate: "1-1-2026")
+
+        XCTAssertFalse(LocationsCK.shouldSkipSave(item: item, serverRecord: nil),
+                       "Without a server record we can't make a skip decision; let the save proceed and rely on CloudKit's own conflict handling")
+    }
+
+    func test_shouldSkipSave_returnsTrueWhenServerCollectedOnSameCycle() throws {
+        let item = try makeItem(recordName: "r1", cycleDate: "1-1-2026")
+        let server = makeServerRecord(collectedFlag: 1, cycleDate: "1-1-2026")
+
+        XCTAssertTrue(LocationsCK.shouldSkipSave(item: item, serverRecord: server),
+                      "Server is source of truth: a collected record on the same cycle must not be overwritten by a stale local edit")
+    }
+
+    func test_shouldSkipSave_returnsFalseWhenServerNotCollected() throws {
+        let item = try makeItem(recordName: "r1", cycleDate: "1-1-2026")
+        let server = makeServerRecord(collectedFlag: 0, cycleDate: "1-1-2026")
+
+        XCTAssertFalse(LocationsCK.shouldSkipSave(item: item, serverRecord: server),
+                       "An uncollected server record is exactly what the local edit means to update; do not skip")
+    }
+
+    func test_shouldSkipSave_returnsFalseWhenServerCollectedOnPriorCycle() throws {
+        let item = try makeItem(recordName: "r1", cycleDate: "1-1-2026")
+        let server = makeServerRecord(collectedFlag: 1, cycleDate: "7-1-2025")
+
+        XCTAssertFalse(LocationsCK.shouldSkipSave(item: item, serverRecord: server),
+                       "Collected-flag is per-cycle; a prior-cycle collection must not block this cycle's save")
+    }
+
+    func test_shouldSkipSave_returnsFalseWhenServerMissingCollectedFlag() throws {
+        let item = try makeItem(recordName: "r1", cycleDate: "1-1-2026")
+        let server = makeServerRecord(collectedFlag: nil, cycleDate: "1-1-2026")
+
+        XCTAssertFalse(LocationsCK.shouldSkipSave(item: item, serverRecord: server),
+                       "Without server-side collected status we cannot conclude collected; do not skip")
+    }
+
     // MARK: - Fixtures
 
     /// A Location CKRecord with every field `init?(withRecord:)` needs, minus the
@@ -181,7 +226,7 @@ class LocationAppTests: XCTestCase {
         return record
     }
 
-    private func makeItem(recordName: String?, locdescription: String = "test", hasPhoto: Bool = false) throws -> LocationRecordCacheItem {
+    private func makeItem(recordName: String?, locdescription: String = "test", hasPhoto: Bool = false, cycleDate: String? = nil) throws -> LocationRecordCacheItem {
         var fields: [String] = [
             "\"QRCode\": \"Q\"",
             "\"latitude\": \"0\"",
@@ -193,8 +238,25 @@ class LocationAppTests: XCTestCase {
         if let recordName = recordName {
             fields.append("\"recordName\": \"\(recordName)\"")
         }
+        if let cycleDate = cycleDate {
+            fields.append("\"cycleDate\": \"\(cycleDate)\"")
+        }
         let json = "{ \(fields.joined(separator: ", ")) }"
         return try JSONDecoder().decode(LocationRecordCacheItem.self, from: Data(json.utf8))
+    }
+
+    /// A minimal "server-side" CKRecord populated only with the fields
+    /// shouldSkipSave reads. Pass nil to omit a field entirely (CKRecord
+    /// returns nil for unset keys, which is the case we want to assert on).
+    private func makeServerRecord(collectedFlag: Int64?, cycleDate: String?) -> CKRecord {
+        let record = CKRecord(recordType: "Location")
+        if let collectedFlag = collectedFlag {
+            record.setValue(collectedFlag, forKey: "collectedFlag")
+        }
+        if let cycleDate = cycleDate {
+            record.setValue(cycleDate, forKey: "cycleDate")
+        }
+        return record
     }
 
     private func removeCacheFileOnDisk() {

--- a/LocationApp/LocationAppTests/LocationAppTests.swift
+++ b/LocationApp/LocationAppTests/LocationAppTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import CloudKit
 @testable import LocationApp
 
 class LocationAppTests: XCTestCase {
@@ -87,7 +88,65 @@ class LocationAppTests: XCTestCase {
         XCTAssertEqual(r1.locdescription, "v2")
     }
 
+    // MARK: - bulkSyncDesiredKeys (Day 3: drop the photo asset from bulk sync)
+
+    func test_bulkSyncDesiredKeys_dropsPhotoButKeepsHasPhoto() {
+        let keys = LocationsCK.bulkSyncDesiredKeys
+        XCTAssertFalse(keys.contains("photo"),
+                       "Bulk sync must not pull the photo CKAsset; it is fetched lazily via fetch(id:)")
+        XCTAssertTrue(keys.contains("hasPhoto"),
+                      "hasPhoto must stay in bulk sync so the UI knows a photo exists without the asset")
+    }
+
+    func test_recordWithoutPhotoField_stillDecodesWithHasPhotoPreserved() throws {
+        // A record as it arrives after desiredKeys filtering: no photo asset.
+        let record = makeLocationRecord()
+        record.setValue(Int64(1), forKey: "hasPhoto")
+
+        let item = try XCTUnwrap(LocationRecordCacheItem(withRecord: record),
+                                 "A photo-less Location record must still decode into a cache item")
+        XCTAssertNil(item.photo, "Bulk sync omits the asset, so photo stays nil until fetch(id:)")
+        XCTAssertTrue(item.hasPhoto, "hasPhoto must survive bulk sync independent of the photo asset")
+    }
+
+    func test_bulkSyncDesiredKeys_coverEveryFieldRequiredToDecodeARecord() {
+        // Build a record holding ONLY the fields bulk sync requests. If
+        // init?(withRecord:) ever needs a field missing from the list, every
+        // synced record would silently fail to decode — this catches that drift.
+        let record = makeLocationRecord(restrictedTo: LocationsCK.bulkSyncDesiredKeys)
+
+        XCTAssertNotNil(LocationRecordCacheItem(withRecord: record),
+                        "bulkSyncDesiredKeys must include every field init?(withRecord:) requires")
+    }
+
     // MARK: - Fixtures
+
+    /// A Location CKRecord with every field `init?(withRecord:)` needs, minus the
+    /// photo CKAsset — i.e. what a record looks like after bulk-sync desiredKeys
+    /// filtering. Pass `restrictedTo` to populate only a subset of fields.
+    private func makeLocationRecord(restrictedTo allowed: [String]? = nil) -> CKRecord {
+        let record = CKRecord(recordType: "Location")
+        func set(_ key: String, _ value: Any) {
+            guard allowed == nil || allowed!.contains(key) else { return }
+            record.setValue(value, forKey: key)
+        }
+        set("QRCode", "Q-1")
+        set("latitude", "37.0")
+        set("longitude", "-122.0")
+        set("locdescription", "a location")
+        set("active", Int64(1))
+        set("dosinumber", "D-1")
+        set("collectedFlag", Int64(0))
+        set("cycleDate", "2026-01")
+        set("mismatch", Int64(0))
+        set("moderator", Int64(0))
+        set("createdDate", Date())
+        set("modifiedDate", Date())
+        set("modifiedBy", "tester")
+        set("reportGroup", "group-1")
+        set("hasPhoto", Int64(0))
+        return record
+    }
 
     private func makeItem(recordName: String?, locdescription: String = "test") throws -> LocationRecordCacheItem {
         var fields: [String] = [

--- a/LocationApp/LocationAppTests/LocationAppTests.swift
+++ b/LocationApp/LocationAppTests/LocationAppTests.swift
@@ -334,6 +334,35 @@ class LocationAppTests: XCTestCase {
                        "add() upserts in place; the lookup must see the latest value at the indexed slot")
     }
 
+    // MARK: - createdDateForSort (nil-safe ordering key)
+
+    func test_createdDateForSort_returnsCreatedDateWhenPresent() throws {
+        // 0 seconds since the reference date == 2001-01-01 00:00:00 UTC.
+        let item = try makeItem(recordName: "r1", createdDate: 0)
+        XCTAssertEqual(item.createdDate, Date(timeIntervalSinceReferenceDate: 0))
+        XCTAssertEqual(item.createdDateForSort, Date(timeIntervalSinceReferenceDate: 0),
+                       "When createdDate is set, the sort key must equal it exactly")
+    }
+
+    func test_createdDateForSort_fallsBackToDistantPastWhenNil() throws {
+        let item = try makeItem(recordName: "r1")
+        XCTAssertNil(item.createdDate, "Fixture without createdDate must decode to nil")
+        XCTAssertEqual(item.createdDateForSort, .distantPast,
+                       "A nil createdDate must sort as the oldest possible date, not crash")
+    }
+
+    func test_createdDateForSort_sortsNilLastInNewestFirstOrder() throws {
+        let newer = try makeItem(recordName: "r1", createdDate: 1000)
+        let older = try makeItem(recordName: "r2", createdDate: 0)
+        let undated = try makeItem(recordName: "r3")
+
+        // Mirrors the UI sort comparators: descending by createdDateForSort.
+        let sorted = [undated, older, newer].sorted { $0.createdDateForSort > $1.createdDateForSort }
+
+        XCTAssertEqual(sorted.map { $0.recordName }, ["r1", "r2", "r3"],
+                       "Newest first, with the nil-createdDate record sorted last")
+    }
+
     // MARK: - Fixtures
 
     /// A Location CKRecord with every field `init?(withRecord:)` needs, minus the
@@ -363,7 +392,7 @@ class LocationAppTests: XCTestCase {
         return record
     }
 
-    private func makeItem(recordName: String?, locdescription: String = "test", hasPhoto: Bool = false, cycleDate: String? = nil) throws -> LocationRecordCacheItem {
+    private func makeItem(recordName: String?, locdescription: String = "test", hasPhoto: Bool = false, cycleDate: String? = nil, createdDate: Double? = nil) throws -> LocationRecordCacheItem {
         var fields: [String] = [
             "\"QRCode\": \"Q\"",
             "\"latitude\": \"0\"",
@@ -377,6 +406,11 @@ class LocationAppTests: XCTestCase {
         }
         if let cycleDate = cycleDate {
             fields.append("\"cycleDate\": \"\(cycleDate)\"")
+        }
+        // JSONDecoder's default .deferredToDate strategy decodes Date from a
+        // Double (seconds since the reference date), so callers pass an interval.
+        if let createdDate = createdDate {
+            fields.append("\"createdDate\": \(createdDate)")
         }
         let json = "{ \(fields.joined(separator: ", ")) }"
         return try JSONDecoder().decode(LocationRecordCacheItem.self, from: Data(json.utf8))

--- a/LocationApp/LocationAppTests/LocationAppTests.swift
+++ b/LocationApp/LocationAppTests/LocationAppTests.swift
@@ -197,6 +197,69 @@ class LocationAppTests: XCTestCase {
                        "Without server-side collected status we cannot conclude collected; do not skip")
     }
 
+    // MARK: - apply-onto-fetched merge (Day 7)
+
+    // Day 7 flips uploadChanges' savePolicy from .allKeys to .ifServerRecordUnchanged
+    // and, for records that exist on the server, applies local fields onto the
+    // *fetched* CKRecord rather than building a fresh one via item.to(). This
+    // preserves the server's recordChangeTag so CloudKit can reject the save when
+    // another device modified the record between our fetch and save. These tests
+    // lock the merge semantics that the new save path depends on.
+
+    func test_update_overwritesServerFieldsWithItemFields() throws {
+        // A server record with the "before" state of every field update() writes.
+        let server = makeLocationRecord()
+        let item = try makeItem(recordName: "r1", locdescription: "north gate")
+        item.dosinumber = "D-NEW"
+        item.collectedFlag = 1
+        item.cycleDate = "1-1-2026"
+        item.moderator = 1
+        item.active = 0
+        item.mismatch = 1
+        item.modifiedBy = "spady"
+        item.reportGroup = "group-7"
+
+        item.update(newRecord: server)
+
+        XCTAssertEqual(server["locdescription"] as? String, "north gate")
+        XCTAssertEqual(server["QRCode"] as? String, "Q")
+        XCTAssertEqual(server["latitude"] as? String, "0")
+        XCTAssertEqual(server["longitude"] as? String, "0")
+        XCTAssertEqual(server["active"] as? Int64, 0)
+        XCTAssertEqual(server["dosinumber"] as? String, "D-NEW")
+        XCTAssertEqual(server["collectedFlag"] as? Int64, 1)
+        XCTAssertEqual(server["cycleDate"] as? String, "1-1-2026")
+        XCTAssertEqual(server["moderator"] as? Int64, 1)
+        XCTAssertEqual(server["mismatch"] as? Int64, 1)
+        XCTAssertEqual(server["modifiedBy"] as? String, "spady")
+        XCTAssertEqual(server["reportGroup"] as? String, "group-7")
+        XCTAssertEqual(server["hasPhoto"] as? Int, 0)
+    }
+
+    func test_update_preservesFetchedRecordID() throws {
+        // uploadChanges relies on update(newRecord:) mutating the *same* CKRecord
+        // object it was handed — that's what carries the fetched recordChangeTag
+        // through to the .ifServerRecordUnchanged save. If update() ever started
+        // returning a new record (or replacing recordID), the conflict check
+        // would silently fall back to a tag-less save.
+        let server = CKRecord(recordType: "Location",
+                              recordID: CKRecord.ID(recordName: "server-id-1"))
+        server.setValue("Q-OLD", forKey: "QRCode")
+        server.setValue("0", forKey: "latitude")
+        server.setValue("0", forKey: "longitude")
+        server.setValue("old", forKey: "locdescription")
+        server.setValue(Int64(0), forKey: "active")
+
+        let item = try makeItem(recordName: "client-cache-id", locdescription: "new")
+
+        item.update(newRecord: server)
+
+        XCTAssertEqual(server.recordID.recordName, "server-id-1",
+                       "update(newRecord:) must mutate the fetched record in place; it must not replace recordID with the item's recordName, or .ifServerRecordUnchanged loses the fetched tag")
+        XCTAssertEqual(server["locdescription"] as? String, "new",
+                       "Field values still flow from item onto the fetched record")
+    }
+
     // MARK: - Fixtures
 
     /// A Location CKRecord with every field `init?(withRecord:)` needs, minus the

--- a/LocationApp/LocationAppTests/LocationAppTests.swift
+++ b/LocationApp/LocationAppTests/LocationAppTests.swift
@@ -11,24 +11,102 @@ import XCTest
 
 class LocationAppTests: XCTestCase {
 
-    override func setUp() {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    // MARK: - Cache.add upsert behavior
+
+    func test_add_appendsNewItem() throws {
+        let cache = Cache()
+        cache.add(try makeItem(recordName: "r1"))
+
+        XCTAssertEqual(cache.locations.count, 1)
+        XCTAssertEqual(cache.locations[0].recordName, "r1")
     }
 
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    func test_add_upsertsByRecordName() throws {
+        let cache = Cache()
+        let first = try makeItem(recordName: "r1", locdescription: "old")
+        let second = try makeItem(recordName: "r1", locdescription: "new")
+
+        cache.add(first)
+        cache.add(second)
+
+        XCTAssertEqual(cache.locations.count, 1, "Adding the same recordName twice must upsert, not duplicate")
+        XCTAssertEqual(cache.locations[0].locdescription, "new")
     }
 
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    func test_add_preservesDistinctRecordNames() throws {
+        let cache = Cache()
+        cache.add(try makeItem(recordName: "r1"))
+        cache.add(try makeItem(recordName: "r2"))
+        cache.add(try makeItem(recordName: "r3"))
+
+        XCTAssertEqual(cache.locations.count, 3)
+        XCTAssertEqual(cache.locations.map { $0.recordName }, ["r1", "r2", "r3"])
     }
 
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
+    func test_add_appendsItemsWithNilRecordName() throws {
+        let cache = Cache()
+        cache.add(try makeItem(recordName: nil))
+        cache.add(try makeItem(recordName: nil))
+
+        XCTAssertEqual(cache.locations.count, 2, "Items lacking a recordName cannot be deduped; they must each append")
+    }
+
+    // MARK: - Cache.clear resets index
+
+    func test_clear_allowsRecycledRecordNameWithoutStaleSlot() throws {
+        let cache = Cache()
+        cache.add(try makeItem(recordName: "r1", locdescription: "before-clear"))
+        cache.clear()
+        cache.add(try makeItem(recordName: "r1", locdescription: "after-clear"))
+
+        XCTAssertEqual(cache.locations.count, 1)
+        XCTAssertEqual(cache.locations[0].locdescription, "after-clear",
+                       "After clear(), re-adding the same recordName must land in a fresh slot, not collide with the cleared index")
+    }
+
+    // MARK: - save/load rebuilds the index
+
+    func test_saveLoad_rebuildsIndexSoSubsequentAddUpserts() throws {
+        removeCacheFileOnDisk()
+        addTeardownBlock { self.removeCacheFileOnDisk() }
+
+        let cache = Cache()
+        cache.add(try makeItem(recordName: "r1", locdescription: "v1"))
+        cache.add(try makeItem(recordName: "r2", locdescription: "v1"))
+        cache.save()
+
+        let loaded = try XCTUnwrap(Cache.load(), "Cache.load() should return the just-saved cache")
+        XCTAssertEqual(loaded.locations.count, 2)
+
+        // If the index wasn't rebuilt after decode, this add() would append a 3rd entry
+        // instead of upserting onto the existing "r1".
+        loaded.add(try makeItem(recordName: "r1", locdescription: "v2"))
+
+        XCTAssertEqual(loaded.locations.count, 2, "Index must be rebuilt after load() so add() still upserts")
+        let r1 = try XCTUnwrap(loaded.locations.first { $0.recordName == "r1" })
+        XCTAssertEqual(r1.locdescription, "v2")
+    }
+
+    // MARK: - Fixtures
+
+    private func makeItem(recordName: String?, locdescription: String = "test") throws -> LocationRecordCacheItem {
+        var fields: [String] = [
+            "\"QRCode\": \"Q\"",
+            "\"latitude\": \"0\"",
+            "\"longitude\": \"0\"",
+            "\"locdescription\": \"\(locdescription)\"",
+            "\"active\": 0",
+            "\"hasPhoto\": false"
+        ]
+        if let recordName = recordName {
+            fields.append("\"recordName\": \"\(recordName)\"")
         }
+        let json = "{ \(fields.joined(separator: ", ")) }"
+        return try JSONDecoder().decode(LocationRecordCacheItem.self, from: Data(json.utf8))
     }
 
+    private func removeCacheFileOnDisk() {
+        let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        try? FileManager.default.removeItem(at: caches.appendingPathComponent("cache.txt"))
+    }
 }

--- a/LocationApp/LocationAppTests/LocationAppTests.swift
+++ b/LocationApp/LocationAppTests/LocationAppTests.swift
@@ -363,6 +363,23 @@ class LocationAppTests: XCTestCase {
                        "Newest first, with the nil-createdDate record sorted last")
     }
 
+    // MARK: - buildDateString (SOW 2.4: auto-derived Tools build date)
+
+    func test_buildDateString_formatsAsMonthCommaYear() {
+        // 2023-05-15 12:00 UTC — mid-month, so no timezone boundary ambiguity.
+        var components = DateComponents()
+        components.year = 2023
+        components.month = 5
+        components.day = 15
+        components.hour = 12
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        let date = calendar.date(from: components)!
+
+        // Matches the "May, 2023" label this replaces (en_US test environment).
+        XCTAssertEqual(ToolsViewController.buildDateString(from: date), "May, 2023")
+    }
+
     // MARK: - Fixtures
 
     /// A Location CKRecord with every field `init?(withRecord:)` needs, minus the

--- a/LocationApp/Map/MapViewController.swift
+++ b/LocationApp/Map/MapViewController.swift
@@ -296,7 +296,7 @@ extension MapViewController {
         var items = self.locations.filter(by: { i in i.createdDate != nil })
         items.sort {
             if $0.QRCode == $1.QRCode {
-                return $0.createdDate! > $1.createdDate!
+                return $0.createdDateForSort > $1.createdDateForSort
             }
             return $0.QRCode < $1.QRCode
         }

--- a/LocationApp/Scanner/ScannerViewController.swift
+++ b/LocationApp/Scanner/ScannerViewController.swift
@@ -589,7 +589,7 @@ extension ScannerViewController {  //queries
         locations.filter(by: { l in l.QRCode == variables.QRCode! && l.createdDate != nil}, completionHandler: { items in
             var litems = [LocationRecordCacheItem](items)
             litems.sort {
-                $0.createdDate! > $1.createdDate!
+                $0.createdDateForSort > $1.createdDateForSort
             }
             var lrecords = [CKRecord]()
             for item in litems {
@@ -635,7 +635,7 @@ extension ScannerViewController {  //queries
         locations.filter(by: { l in l.QRCode == tempQR && l.createdDate != nil}, completionHandler: {items in
             var litems = [LocationRecordCacheItem](items)
             litems.sort {
-                $0.createdDate! > $1.createdDate!
+                $0.createdDateForSort > $1.createdDateForSort
             }
             var lrecords = [CKRecord]()
             for item in litems {
@@ -974,6 +974,17 @@ extension ScannerViewController {  //alerts
                     label.text = "Please enter a location"
                     label.isHidden = false
                     self.present(alert, animated: true, completion: nil)
+                } else if variables.QRCode == nil {
+                    // Hardening (SOW V2 Rev 1): refuse to deploy a location whose
+                    // QR code never got captured. Saving here would persist the
+                    // "Nil QRCode" placeholder to CloudKit (see setValue below),
+                    // which can't be reconciled later. Bounce back to the scanner
+                    // so the field worker rescans the location QR code.
+                    let qrError = UIAlertController(title: "Location QR Code Missing", message: "The location QR code wasn't captured. Please scan the location QR code again before deploying.", preferredStyle: .alert)
+                    qrError.addAction(UIAlertAction(title: "OK", style: .default, handler: self.handlerCancel))
+                    DispatchQueue.main.async {
+                        self.present(qrError, animated: true, completion: nil)
+                    }
                 } else {
                     let description = text.replacingOccurrences(of: ",", with: "-")
                     let newRecord = CKRecord(recordType: "Location")

--- a/LocationApp/Utility View/ActiveLocations.swift
+++ b/LocationApp/Utility View/ActiveLocations.swift
@@ -167,7 +167,7 @@ extension ActiveLocations : UIViewControllerTransitioningDelegate{
    } //end func
         
     func addLocation(_ records: [LocationRecordCacheItem]) {
-        if let item = records.max(by: { $0.createdDate! < $1.createdDate! }) {
+        if let item = records.max(by: { $0.createdDateForSort < $1.createdDateForSort }) {
             let flag = item.active == 1 ? 0 : 1
             displayInfo[flag].append((item, item.QRCode, item.locdescription))
         }

--- a/LocationApp/Utility View/DosimetersViewController.swift
+++ b/LocationApp/Utility View/DosimetersViewController.swift
@@ -17,13 +17,14 @@ class Dosimeter {
     var collected: String?
     var createdDate:Date
     
-    init(item: LocationRecordCacheItem) {
+    init?(item: LocationRecordCacheItem) {
+        guard let createdDate = item.createdDate else { return nil }
         qrCode = item.QRCode
         self.moderator = Dosimeter.fromInt(item.moderator)
         self.collected = Dosimeter.fromInt(item.collectedFlag)
         dosinumber = item.dosinumber
         cycleDate = item.cycleDate
-        createdDate = item.createdDate!
+        self.createdDate = createdDate
     }
     
     private static func fromInt(_ value:Int64?) -> String {
@@ -73,7 +74,7 @@ class DosimetersViewController: UIViewController {
     }
     
     fileprivate func processItems(_ items: [LocationRecordCacheItem]) {
-        var dosis = items.map({ item in Dosimeter(item: item)})
+        var dosis = items.compactMap({ item in Dosimeter(item: item) })
         dosis.sort {
             if $0.qrCode == $1.qrCode {
                 return $0.createdDate > $1.createdDate

--- a/LocationApp/Utility View/LocationDetails.swift
+++ b/LocationApp/Utility View/LocationDetails.swift
@@ -424,23 +424,30 @@ extension LocationDetails: UITextFieldDelegate {
         //        dispatchGroup.enter()
         
         let text = pDescription.text?.replacingOccurrences(of: ",", with: "-")
-        
+
+        // Edit a distinct copy, not the cache's live record. popupRecord aliases
+        // the cached LocationRecordCacheItem; mutating it in place set collectedFlag
+        // before LocationsCK.save's already-collected guard ran, so the guard
+        // compared the record against itself and silently dropped a genuine collect
+        // (QA-1 DEFECT-1). Saving a copy lets the guard see the true prior state.
+        let item = (popupRecord as! LocationRecordCacheItem).copy()
+
         //set new record information
-        popupRecord.setValue(text, forKey: "locdescription")
-        popupRecord.setValue(pLatitude.text, forKey: "latitude")
-        popupRecord.setValue(pLongitude.text, forKey: "longitude")
-        popupRecord.setValue(pDosimeter.text, forKey: "dosinumber")
-        popupRecord.setValue(moderator, forKey: "moderator")
-        popupRecord.setValue(pReportGroup.text, forKey: "reportGroup")
+        item.setValue(text, forKey: "locdescription")
+        item.setValue(pLatitude.text, forKey: "latitude")
+        item.setValue(pLongitude.text, forKey: "longitude")
+        item.setValue(pDosimeter.text, forKey: "dosinumber")
+        item.setValue(moderator, forKey: "moderator")
+        item.setValue(pReportGroup.text, forKey: "reportGroup")
         if pDosimeter.text != "" {
-            popupRecord.setValue(pCycleDate.text, forKey: "cycleDate")
-            popupRecord.setValue(collected, forKey: "collectedFlag")
-            popupRecord.setValue(mismatch, forKey: "mismatch")
+            item.setValue(pCycleDate.text, forKey: "cycleDate")
+            item.setValue(collected, forKey: "collectedFlag")
+            item.setValue(mismatch, forKey: "mismatch")
         }
         //not handled if dosimeter number is empty.  Therefore can't set collected flag.
-        
+
         activityIndicator.startAnimating()
-        locations.save(item: popupRecord as! LocationRecordCacheItem, completionHandler: { self.activityIndicator.stopAnimating() })
+        locations.save(item: item, completionHandler: { self.activityIndicator.stopAnimating() })
     } //end saveActiveStatus
     
     func setPopupDetails(record: LocationRecordDelegate) {

--- a/LocationApp/Utility View/LocationDetails.swift
+++ b/LocationApp/Utility View/LocationDetails.swift
@@ -326,7 +326,7 @@ extension LocationDetails: UITableViewDelegate, UITableViewDataSource {
         
         var items = locations.filter(by: { l in l.QRCode == QRCode && l.createdDate != nil })
         items.sort {
-            $0.createdDate! > $1.createdDate!
+            $0.createdDateForSort > $1.createdDateForSort
         }
         for item in items {
             recordFetchedBlock(record: item)

--- a/LocationApp/Utility View/ToolsViewController.swift
+++ b/LocationApp/Utility View/ToolsViewController.swift
@@ -224,7 +224,7 @@ extension ToolsViewController {
         var items = locations.filter(by: filter)
         items.sort {
             if $0.QRCode == $1.QRCode {
-                return $0.createdDate! > $1.createdDate!
+                return $0.createdDateForSort > $1.createdDateForSort
             }
             return $0.QRCode < $1.QRCode
         }

--- a/LocationApp/Utility View/ToolsViewController.swift
+++ b/LocationApp/Utility View/ToolsViewController.swift
@@ -124,12 +124,25 @@ class ToolsViewController: UIViewController, MFMailComposeViewControllerDelegate
     }
     
     @IBAction func resetCacheTouchUp(_ sender: Any) {
-        activityIndicator.startAnimating()
-        locations.reset { _ in
-            DispatchQueue.main.async {
-                self.activityIndicator.stopAnimating()
+        let pending = locations.pendingChangeCount
+        let pendingLine = pending > 0
+            ? "\n\nYou have \(pending) unsynced edit\(pending == 1 ? "" : "s") that will sync first."
+            : ""
+        let alert = UIAlertController(
+            title: "Reset Cache?",
+            message: "This will discard the local cache and reload all location data from CloudKit. Use this only if records appear out of sync.\(pendingLine)",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        alert.addAction(UIAlertAction(title: "Reset", style: .destructive, handler: { _ in
+            self.activityIndicator.startAnimating()
+            self.locations.reset { _ in
+                DispatchQueue.main.async {
+                    self.activityIndicator.stopAnimating()
+                }
             }
-        }
+        }))
+        present(alert, animated: true)
     }
     
     //MARK:  Send Email

--- a/LocationApp/Utility View/ToolsViewController.swift
+++ b/LocationApp/Utility View/ToolsViewController.swift
@@ -38,6 +38,7 @@ class ToolsViewController: UIViewController, MFMailComposeViewControllerDelegate
 
     
     @IBOutlet weak var activityIndicator: UIActivityIndicatorView!
+    @IBOutlet weak var buildDateLabel: UILabel!
     @IBOutlet weak var button1: UIButton!
     @IBOutlet weak var button2: UIButton!
     @IBOutlet weak var button3: UIButton!
@@ -69,7 +70,33 @@ class ToolsViewController: UIViewController, MFMailComposeViewControllerDelegate
         
         registerDevMode()
 
+        //show the build date (auto-derived) instead of a hardcoded string
+        buildDateLabel.text = ToolsViewController.buildDateString()
+
         // function which is triggered when handleTap is called
+    }
+
+    //Auto-derived build date for the Tools footer. Reads the modification date
+    //of the compiled executable (stamped fresh on every build), falling back to
+    //the Info.plist date, then to nil if neither is readable.
+    static func buildDateString() -> String {
+        let candidates = [Bundle.main.executableURL,
+                          Bundle.main.url(forResource: "Info", withExtension: "plist")]
+        for url in candidates.compactMap({ $0 }) {
+            if let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+               let date = attrs[.modificationDate] as? Date {
+                return buildDateString(from: date)
+            }
+        }
+        return ""
+    }
+
+    //Formats a build date as e.g. "May, 2023" to match the label this replaces.
+    //Pure (offline-testable) — kept separate from the bundle read above.
+    static func buildDateString(from date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM, yyyy"
+        return formatter.string(from: date)
     }
     
     private func addBorderToButton(button: UIButton) {


### PR DESCRIPTION
  ### What this does
  Reworks the Reset Cache / CloudKit sync path so concurrent users can no longer
  overwrite completed records, and hardens the sync + scanner code against the
  crashes seen in the field. Implements SOW §2.1 plus the V2 Rev 1 hardening
  (nil-QRCode + nil-`createdDate` sweep). Also includes the SOW §2.4 build/version
  change (Version 3 + auto-derived build date).

  ### Why
  Technicians were overusing Reset Cache (sometimes after every collect). On a
  cache reset, stale local records were being re-uploaded and **overwriting good
  `collected = True` records in CloudKit**. Desired behavior: once a record reads
  `collected = True` in CloudKit, no further client write should clobber it.

  ### Changes (grouped)

  **Write safety — stop clobbering completed/server records**
  - `fd6a667` Guard against re-saving locally-collected records
  - `771de5c` Skip server and collected records on upload
  - `b2a6c54` Apply local fields onto fetched server records
  - `590b67e` Fetch current server records
  - `627083e` Save a copy on popup edit to fix dropped collect (QA-1 DEFECT-1 — popup edit aliased the live cache record, fooling the already-collected guard)

  **Reset Cache UX — curb overuse**
  - `12633f3` Confirm Reset Cache before destroying local state
  - `aabb76f` Add `pendingChangeCount` accessor for Reset Cache (warn when unsynced edits would be lost)

  **Sync performance (cold-load on large sets)**
  - `27ec7cf` Exclude photo asset from bulk location sync (`desiredKeys` allowlist; photos load lazily)
  - `51dc07c` Index Cache locations by recordName (O(1) upsert vs. linear scan)
  - `98b61f9` Reduce CloudKit upload batch size 400→200
  - `ef9508e` Refactor `uploadChanges` to operate on cache items

  **Crash hardening (SOW V2 Rev 1)**
  - `13e9d69` Harden nil createdDate and missing QRCode
  - `931ccc2` Skip locations with nil createdDate
  - Nil-QRCode deploy guard (alert 8): refuses to persist the `"Nil QRCode"` placeholder, bounces to scanner.
  - nil-`createdDate` sweep: all sort sites use a nil-safe ordering key; the one genuine crash site was Active/Nearest.

  **Build & version (SOW §2.4)**
  - `c74c441` Auto-derive the Tools build date — replaces the hardcoded `"May, 2023"` storyboard label with a date derived from the build (executable mtime, `"MMMM, yyyy"`), wired through a new `buildDateLabel`
  outlet; mirrors the dynamic version label on Startup. Bumps `MARKETING_VERSION` 2.0 → 3.0.

  ### Testing
  - Unit tests (offline, no CloudKit), **32 passing**: Cache recordName indexing + upsert, save/load round-trips, `bulkSyncDesiredKeys`, `LocationRecordCacheItem.to()`, `createdDateForSort` ordering, server/local
  skip decisions, build-date formatting.
  - QA Day 1 (06-03): two-device concurrent collect + Reset Cache confirmation — signed off (surfaced & fixed DEFECT-1).
  - QA Day 2 (06-04): cold-sync timing on 1000+ records (baseline vs. branch), hardening C1/C2 audit — see results log.

  ### Acceptance
  - [x] Cold-sync timing shows measurable improvement on 1000+ records — **≈8.2× faster cold load (15.14s → 1.85s median, ~88% reduction)** on 1270 records / 1200 photo-bearing (06-04). Driver: photo-excluded
  `desiredKeys` (`27ec7cf`); win scales with photo volume.
  - [x] Two-device concurrent test produces no regression of an already-collected record (QA-1, 06-03)