### PR TITLE
Fix offline second-scan crash

### DIFF
--- a/LocationApp/Location Cache/Locations.swift
+++ b/LocationApp/Location Cache/Locations.swift
@@ -449,6 +449,8 @@ class LocationsCK : Locations, SettingsService {
                     let settings = Settings()
                     settings.dosimeterMinimumLength = record["dosimeterMinimumLength"] as? Int ?? 11
                     settings.dosimeterMaximumLength = record["dosimeterMaximumLength"] as? Int ?? 11
+                    settings.defaultLatitude = record["defaultLatitude"] as? Double
+                    settings.defaultLongitude = record["defaultLongitude"] as? Double
                     self.cache!.setSettings(settings: settings)
                 }
             }            

--- a/LocationApp/Location Cache/Settings.swift
+++ b/LocationApp/Location Cache/Settings.swift
@@ -7,8 +7,19 @@
 //
 
 import Foundation
+import CoreLocation
 
 class Settings : Codable {
     var dosimeterMinimumLength : Int = 11
     var dosimeterMaximumLength : Int = 11
+    //Fallback scan coordinates for when there is no GPS fix (e.g. WiFi-only
+    //iPads with WiFi off). Configurable via the CloudKit Settings record;
+    //optional so caches saved before these fields existed still decode.
+    var defaultLatitude : Double?
+    var defaultLongitude : Double?
+
+    var defaultCoordinates: CLLocation {
+        return CLLocation(latitude: defaultLatitude ?? 37.41927542738301,
+                          longitude: defaultLongitude ?? -122.20517033784913)
+    }
 }

--- a/LocationApp/LocationAppTests/LocationAppTests.swift
+++ b/LocationApp/LocationAppTests/LocationAppTests.swift
@@ -380,6 +380,55 @@ class LocationAppTests: XCTestCase {
         XCTAssertEqual(ToolsViewController.buildDateString(from: date), "May, 2023")
     }
 
+    // MARK: - Settings fallback coordinates (SOW R3-a: offline scan, no GPS fix)
+
+    // Devices in the field have a cached Settings JSON written before the
+    // coordinate fields existed. They must stay decodable — the fields are
+    // optional for exactly this reason — and the accessor must fall back to the
+    // SOW R3 coordinate. If decode ever starts failing here, shipping it would
+    // break every already-deployed cache.
+    func test_settingsDecode_withoutCoordinateFields_succeedsAndUsesFallback() throws {
+        let oldFormat = #"{"dosimeterMinimumLength": 11, "dosimeterMaximumLength": 11}"#
+
+        let settings = try JSONDecoder().decode(Settings.self, from: Data(oldFormat.utf8))
+
+        XCTAssertNil(settings.defaultLatitude)
+        XCTAssertNil(settings.defaultLongitude)
+        XCTAssertEqual(settings.defaultCoordinates.coordinate.latitude, 37.41927542738301, accuracy: 0.000001)
+        XCTAssertEqual(settings.defaultCoordinates.coordinate.longitude, -122.20517033784913, accuracy: 0.000001)
+    }
+
+    func test_settingsDecode_withCoordinateFields_usesConfiguredValues() throws {
+        let configured = #"{"dosimeterMinimumLength": 11, "dosimeterMaximumLength": 11, "defaultLatitude": 37.5, "defaultLongitude": -122.5}"#
+
+        let settings = try JSONDecoder().decode(Settings.self, from: Data(configured.utf8))
+
+        XCTAssertEqual(settings.defaultCoordinates.coordinate.latitude, 37.5, accuracy: 0.000001)
+        XCTAssertEqual(settings.defaultCoordinates.coordinate.longitude, -122.5, accuracy: 0.000001)
+    }
+
+    func test_defaultCoordinates_fallsBackPerAxisWhenPartiallyConfigured() {
+        // Only one field set in CloudKit (a half-finished edit of the Settings
+        // record) must not zero the other axis.
+        let settings = Settings()
+        settings.defaultLatitude = 37.5
+
+        XCTAssertEqual(settings.defaultCoordinates.coordinate.latitude, 37.5, accuracy: 0.000001)
+        XCTAssertEqual(settings.defaultCoordinates.coordinate.longitude, -122.20517033784913, accuracy: 0.000001)
+    }
+
+    func test_settings_roundTripPreservesCoordinateFields() throws {
+        let settings = Settings()
+        settings.defaultLatitude = 37.5
+        settings.defaultLongitude = -122.5
+
+        let data = try JSONEncoder().encode(settings)
+        let reloaded = try JSONDecoder().decode(Settings.self, from: data)
+
+        XCTAssertEqual(reloaded.defaultLatitude, 37.5)
+        XCTAssertEqual(reloaded.defaultLongitude, -122.5)
+    }
+
     // MARK: - Fixtures
 
     /// A Location CKRecord with every field `init?(withRecord:)` needs, minus the

--- a/LocationApp/Scanner/ScannerViewController.swift
+++ b/LocationApp/Scanner/ScannerViewController.swift
@@ -508,18 +508,20 @@ extension ScannerViewController {
         variables.cycle = RecordsUpdate.generateCycleDate()
         
         locationManager.requestAlwaysAuthorization()
-        var currentLocation = CLLocation()
-        //location can be nil on WiFi-only iPads when WiFi is off (no WiFi
-        //positioning fix). Fall through with the default (0,0) location so the
-        //out-of-range retry flow (alert15 -> default coordinates) handles it.
-        if (locationManager.authorizationStatus == .authorizedWhenInUse ||
-            locationManager.authorizationStatus ==  .authorizedAlways),
-            let location = locationManager.location {
-            currentLocation = location
+        //location is nil when there is no GPS fix at all (e.g. WiFi-only iPads
+        //with WiFi off). Retrying can't produce a fix, so assign the fallback
+        //coordinates (configurable via the CloudKit Settings record) directly
+        //instead of sending the user through the alert15 retry loop.
+        guard (locationManager.authorizationStatus == .authorizedWhenInUse ||
+               locationManager.authorizationStatus ==  .authorizedAlways),
+              let currentLocation = locationManager.location else {
+            setCoordinates(currentLocation: settings?.defaultCoordinates ?? Slac.defaultCoordinates)
+            self.alert8()
+            return
         }
-        
+
         if(Slac.isLocationInRange(location: currentLocation) || outOfRangeCounter >= numberOfGPSRetry ) {
-            setCoordinates(currentLocation: (outOfRangeCounter >= numberOfGPSRetry ? Slac.defaultCoordinates : currentLocation))
+            setCoordinates(currentLocation: (outOfRangeCounter >= numberOfGPSRetry ? (settings?.defaultCoordinates ?? Slac.defaultCoordinates) : currentLocation))
             self.alert8()
         } else{
             //Wrong Location, Show Try Again alert

--- a/LocationApp/Scanner/ScannerViewController.swift
+++ b/LocationApp/Scanner/ScannerViewController.swift
@@ -509,9 +509,13 @@ extension ScannerViewController {
         
         locationManager.requestAlwaysAuthorization()
         var currentLocation = CLLocation()
+        //location can be nil on WiFi-only iPads when WiFi is off (no WiFi
+        //positioning fix). Fall through with the default (0,0) location so the
+        //out-of-range retry flow (alert15 -> default coordinates) handles it.
         if (locationManager.authorizationStatus == .authorizedWhenInUse ||
-            locationManager.authorizationStatus ==  .authorizedAlways) {
-            currentLocation = locationManager.location!
+            locationManager.authorizationStatus ==  .authorizedAlways),
+            let location = locationManager.location {
+            currentLocation = location
         }
         
         if(Slac.isLocationInRange(location: currentLocation) || outOfRangeCounter >= numberOfGPSRetry ) {


### PR DESCRIPTION
Fixes the crash reported 6/10 when scanning a dosimeter with WiFi off: the QR scan completed but the app crashed on the second (Code128) scan. Root cause was a force unwrap of `locationManager.location` in the scanner's save path — on a WiFi-only iPad with WiFi off there is no positioning fix, so the location is nil. The bug predates all recent work; it has been in the save path since the first commit.

## What changed
**Crash fix (`98572c1`):** the force unwrap is replaced with optional binding, so a missing GPS fix can no longer crash the scanner.

**Fallback coordinates per SOW Revision 3 (`1302e41`):** when there is no GPS fix at all, the app now assigns 37.41927542738301, -122.20517033784913 immediately and completes the save, instead of walking the operator through "Try Again" GPS alerts that cannot succeed without a fix. Implemented as the configurable variant from the SOW: the coordinate lives in the same CloudKit `Settings` record as the barcode lengths, in two new optional fields `defaultLatitude` and `defaultLongitude` (Double). When the fields are absent, the app uses the coordinate above, so no CloudKit change is required to deploy this.

## What did not change
- A real GPS fix that is off-site still goes through the existing retry flow (alert 15, two retries, then standard coordinates), now using the same configurable fallback on the final assignment.
- Online scans with a valid fix behave exactly as before.
- Map and Nearest Dosimeters views are untouched.

## Configuration note
To override the fallback coordinate later, add `defaultLatitude` and `defaultLongitude` (Double) to the existing `Settings` record type in CloudKit and set the values — the app picks them up on its next settings sync. Until then the built-in coordinate applies. Saved coordinates remain adjustable per-record in the Tools menu as before.

## Testing
- 4 new unit tests cover the Settings changes: decode compatibility with cached settings written before the new fields existed (the upgrade-safety case), the configured-value override, per-axis fallback when only one field is set, and an encode/decode round trip. Suite 36/36 green.
- Retested offline on a physical device with the fresh barcodes (QR BLG 044-004, dosimeter 21111111116): no crash, no GPS error alerts, and the record saves with the specified fallback coordinates. Online scan re-verified unchanged.