### PR TITLE
Delete Old Cycles: passcode-gated super-user purge with forced export safeguard

### DIFF
--- a/LocationApp/Location Cache/Cache.swift
+++ b/LocationApp/Location Cache/Cache.swift
@@ -77,8 +77,12 @@ class Cache: Codable {
     func remove(recordNames: Set<String>) -> Int {
         guard !recordNames.isEmpty else { return 0 }
         let before = locations.count
-        locations.removeAll { $0.recordName != nil && recordNames.contains($0.recordName!) }
-        changes.removeAll { $0.recordName != nil && recordNames.contains($0.recordName!) }
+        let isNamed: (LocationRecordCacheItem) -> Bool = { item in
+            guard let name = item.recordName else { return false }
+            return recordNames.contains(name)
+        }
+        locations.removeAll(where: isNamed)
+        changes.removeAll(where: isNamed)
         rebuildLocationIndex()
         return before - locations.count
     }

--- a/LocationApp/Location Cache/Cache.swift
+++ b/LocationApp/Location Cache/Cache.swift
@@ -70,6 +70,21 @@ class Cache: Codable {
         return locations[i]
     }
 
+    // Removes the records with the given recordNames from the locations array
+    // AND the pending-changes queue, then rebuilds the transient index. The
+    // changes queue is pruned too so a deleted record can't be resurrected by
+    // a queued upload on the next sync. Items with a nil recordName are never
+    // touched. Returns how many location records were removed.
+    @discardableResult
+    func remove(recordNames: Set<String>) -> Int {
+        guard !recordNames.isEmpty else { return 0 }
+        let before = locations.count
+        locations.removeAll { $0.recordName != nil && recordNames.contains($0.recordName!) }
+        changes.removeAll { $0.recordName != nil && recordNames.contains($0.recordName!) }
+        rebuildLocationIndex()
+        return before - locations.count
+    }
+
     func addChange(_ item: LocationRecordCacheItem) {
         item.setValue(user, forKey: "modifiedBy")
         if let index = changes.firstIndex(where: { l in l.recordName == item.recordName}) {

--- a/LocationApp/Location Cache/Cache.swift
+++ b/LocationApp/Location Cache/Cache.swift
@@ -70,11 +70,9 @@ class Cache: Codable {
         return locations[i]
     }
 
-    // Removes the records with the given recordNames from the locations array
-    // AND the pending-changes queue, then rebuilds the transient index. The
-    // changes queue is pruned too so a deleted record can't be resurrected by
-    // a queued upload on the next sync. Items with a nil recordName are never
-    // touched. Returns how many location records were removed.
+    // Removes the named records from the locations array AND the
+    // pending-changes queue (so a queued upload can't resurrect them),
+    // then rebuilds the index. Returns how many records were removed.
     @discardableResult
     func remove(recordNames: Set<String>) -> Int {
         guard !recordNames.isEmpty else { return 0 }

--- a/LocationApp/Location Cache/Locations.swift
+++ b/LocationApp/Location Cache/Locations.swift
@@ -30,6 +30,10 @@ protocol Locations {
     func fetch(id: String, completionHandler: @escaping (LocationRecordCacheItem?, Error?) -> Void)
 
     var pendingChangeCount: Int { get }
+
+    func eligibleOldCycleRecords(keepingCycles: Int) -> [LocationRecordCacheItem]
+
+    func deleteOldCycleRecords(keepingCycles: Int, progress: @escaping (Int, Int) -> Void, completion: @escaping (Int, Error?) -> Void)
 }
 
 class LocationsCK : Locations, SettingsService {
@@ -213,6 +217,104 @@ class LocationsCK : Locations, SettingsService {
         guard let cached = cached else { return false }
         guard cached.collectedFlag == 1, let cachedCycle = cached.cycleDate else { return false }
         return cachedCycle == item.cycleDate
+    }
+
+    //MARK:  Super-user delete (SOW 2.2)
+
+    // Pure decision used by deleteOldCycleRecords: a record may be deleted only
+    // when it carries a cycleDate that is NOT among the protected (most recent)
+    // cycles. Records with a nil cycleDate are never deleted — we can't prove
+    // they're old, so the conservative answer is to keep them.
+    // Internal (not private) so LocationAppTests can drive the decision matrix
+    // offline; same exception precedent as shouldSkipSave.
+    internal static func isEligibleForCycleDeletion(item: LocationRecordCacheItem, protectedCycles: [String]) -> Bool {
+        guard let cycleDate = item.cycleDate else { return false }
+        return !protectedCycles.contains(cycleDate)
+    }
+
+    // Records eligible for super-user deletion: everything whose cycleDate falls
+    // outside the most recent keepingCycles cycles. The admin screen uses this
+    // to preview the count before any deletion is confirmed.
+    func eligibleOldCycleRecords(keepingCycles: Int) -> [LocationRecordCacheItem] {
+        let protectedCycles = RecordsUpdate.getLastCycles(cycles: keepingCycles)
+        return filter(by: { LocationsCK.isEligibleForCycleDeletion(item: $0, protectedCycles: protectedCycles) })
+    }
+
+    static let deleteOfflineError = NSError(domain: "LocationApp", code: 503,
+        userInfo: [NSLocalizedDescriptionKey: "No network connection. Deletion stopped — records already deleted are gone; the rest are untouched."])
+
+    // Deletes every eligible old-cycle record from CloudKit in pages of 200,
+    // mirroring uploadChanges' pagination. Eligibility is recomputed here, not
+    // trusted from the caller, so the most-recent-cycles protection holds even
+    // if the UI ever passes something stale. Per batch: only records CloudKit
+    // confirms deleted are dropped from the cache (a failed delete stays visible
+    // locally so a retry can pick it up), progress reports on the main queue,
+    // and connectivity loss stops the run gracefully between batches.
+    // Every step prints — the operation must be auditable from the console log.
+    func deleteOldCycleRecords(keepingCycles: Int, progress: @escaping (Int, Int) -> Void, completion: @escaping (Int, Error?) -> Void) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let names = self.eligibleOldCycleRecords(keepingCycles: keepingCycles).compactMap { $0.recordName }
+            let total = names.count
+            print("Super-user delete: \(total) records eligible (keeping last \(keepingCycles) cycles)")
+            guard total > 0 else {
+                DispatchQueue.main.async { completion(0, nil) }
+                return
+            }
+
+            var deleted = 0
+            let size = 200
+            var start = 0
+            while start < names.count {
+                // Graceful interruption: stop between batches the moment
+                // connectivity drops; everything deleted so far stays deleted.
+                if self.reachability.connection == .none {
+                    print("Super-user delete: connectivity lost after \(deleted)/\(total); stopping")
+                    DispatchQueue.main.async { completion(deleted, LocationsCK.deleteOfflineError) }
+                    return
+                }
+                let batch = Array(names[start..<min(start + size, names.count)])
+                start += size
+
+                var succeeded: [String] = []
+                var batchError: Error? = nil
+                let operation = CKModifyRecordsOperation(recordsToSave: nil,
+                                                         recordIDsToDelete: batch.map { CKRecord.ID(recordName: $0) })
+                operation.qualityOfService = .userInitiated
+                operation.perRecordDeleteBlock = { id, result in
+                    switch result {
+                    case .success:
+                        succeeded.append(id.recordName)
+                    case .failure(let error):
+                        print("Super-user delete failed for \(id.recordName): \(error.localizedDescription)")
+                        batchError = error
+                    }
+                }
+                operation.modifyRecordsResultBlock = { result in
+                    if case .failure(let error) = result {
+                        batchError = error
+                    }
+                }
+                self.database.add(operation)
+                operation.waitUntilFinished()
+
+                if !succeeded.isEmpty {
+                    self.semaphore.wait()
+                    let removed = self.cache?.remove(recordNames: Set(succeeded)) ?? 0
+                    self.cache?.save()
+                    self.semaphore.signal()
+                    deleted += succeeded.count
+                    print("Super-user delete: batch deleted \(succeeded.count) from cloud, removed \(removed) from cache (\(deleted)/\(total))")
+                    DispatchQueue.main.async { progress(deleted, total) }
+                }
+                if let error = batchError {
+                    print("Super-user delete: stopping after error with \(deleted)/\(total) deleted")
+                    DispatchQueue.main.async { completion(deleted, error) }
+                    return
+                }
+            }
+            print("Super-user delete: completed, \(deleted)/\(total) records deleted")
+            DispatchQueue.main.async { completion(deleted, nil) }
+        }
     }
 
     // Fetches the current server-side records for the given IDs. uploadChanges

--- a/LocationApp/Location Cache/Locations.swift
+++ b/LocationApp/Location Cache/Locations.swift
@@ -219,22 +219,18 @@ class LocationsCK : Locations, SettingsService {
         return cachedCycle == item.cycleDate
     }
 
-    //MARK:  Super-user delete (SOW 2.2)
+    //MARK:  Super-user delete
 
-    // Pure decision used by deleteOldCycleRecords: a record may be deleted only
-    // when it carries a cycleDate that is NOT among the protected (most recent)
-    // cycles. Records with a nil cycleDate are never deleted — we can't prove
-    // they're old, so the conservative answer is to keep them.
-    // Internal (not private) so LocationAppTests can drive the decision matrix
-    // offline; same exception precedent as shouldSkipSave.
+    // A record may be deleted only when its cycleDate is NOT among the
+    // protected (most recent) cycles; a nil cycleDate is never deletable.
+    // Internal so LocationAppTests can drive the decision matrix offline.
     internal static func isEligibleForCycleDeletion(item: LocationRecordCacheItem, protectedCycles: [String]) -> Bool {
         guard let cycleDate = item.cycleDate else { return false }
         return !protectedCycles.contains(cycleDate)
     }
 
-    // Records eligible for super-user deletion: everything whose cycleDate falls
-    // outside the most recent keepingCycles cycles. The admin screen uses this
-    // to preview the count before any deletion is confirmed.
+    // Everything whose cycleDate falls outside the most recent keepingCycles
+    // cycles. The admin screen uses this to preview the affected records.
     func eligibleOldCycleRecords(keepingCycles: Int) -> [LocationRecordCacheItem] {
         let protectedCycles = RecordsUpdate.getLastCycles(cycles: keepingCycles)
         return filter(by: { LocationsCK.isEligibleForCycleDeletion(item: $0, protectedCycles: protectedCycles) })
@@ -243,14 +239,9 @@ class LocationsCK : Locations, SettingsService {
     static let deleteOfflineError = NSError(domain: "LocationApp", code: 503,
         userInfo: [NSLocalizedDescriptionKey: "No network connection. Deletion stopped — records already deleted are gone; the rest are untouched."])
 
-    // Deletes every eligible old-cycle record from CloudKit in pages of 200,
-    // mirroring uploadChanges' pagination. Eligibility is recomputed here, not
-    // trusted from the caller, so the most-recent-cycles protection holds even
-    // if the UI ever passes something stale. Per batch: only records CloudKit
-    // confirms deleted are dropped from the cache (a failed delete stays visible
-    // locally so a retry can pick it up), progress reports on the main queue,
-    // and connectivity loss stops the run gracefully between batches.
-    // Every step prints — the operation must be auditable from the console log.
+    // Deletes every eligible old-cycle record from CloudKit in pages of 200.
+    // Eligibility is recomputed here rather than trusted from the caller; only
+    // confirmed deletions leave the cache, and every step prints for audit.
     func deleteOldCycleRecords(keepingCycles: Int, progress: @escaping (Int, Int) -> Void, completion: @escaping (Int, Error?) -> Void) {
         DispatchQueue.global(qos: .userInitiated).async {
             let names = self.eligibleOldCycleRecords(keepingCycles: keepingCycles).compactMap { $0.recordName }
@@ -553,6 +544,7 @@ class LocationsCK : Locations, SettingsService {
                     settings.dosimeterMaximumLength = record["dosimeterMaximumLength"] as? Int ?? 11
                     settings.defaultLatitude = record["defaultLatitude"] as? Double
                     settings.defaultLongitude = record["defaultLongitude"] as? Double
+                    settings.superUserPasscode = record["superUserPasscode"] as? Int
                     self.cache!.setSettings(settings: settings)
                 }
             }            

--- a/LocationApp/Location Cache/Settings.swift
+++ b/LocationApp/Location Cache/Settings.swift
@@ -22,4 +22,13 @@ class Settings : Codable {
         return CLLocation(latitude: defaultLatitude ?? 37.41927542738301,
                           longitude: defaultLongitude ?? -122.20517033784913)
     }
+
+    //Super-user passcode for the delete-old-cycles screen, configurable via
+    //the CloudKit Settings record. Optional like the coordinates above so
+    //caches saved before this field existed still decode.
+    var superUserPasscode : Int?
+
+    var superUserPasscodeValue: Int {
+        return superUserPasscode ?? 4299
+    }
 }

--- a/LocationApp/LocationApp.xcodeproj/project.pbxproj
+++ b/LocationApp/LocationApp.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		5AC96E122A2E09F10022068C /* RestoreLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AC96E112A2E09F10022068C /* RestoreLocation.swift */; };
 		5C7925A122DE9B1900B981B2 /* LocationDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C7925A022DE9B1900B981B2 /* LocationDetails.swift */; };
 		5CF01FDE22D92F19004604BC /* ToolsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF01FDD22D92F19004604BC /* ToolsViewController.swift */; };
+		DA20260611000000000000A2 /* DeleteOldCyclesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA20260611000000000000A1 /* DeleteOldCyclesViewController.swift */; };
 		5CFF888B22CAA5B700611F60 /* ActiveLocations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFF888A22CAA5B700611F60 /* ActiveLocations.swift */; };
 		5E4D12742A2776E9002E4D91 /* Slac.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4D12732A2776E9002E4D91 /* Slac.swift */; };
 		5E660CC12A3AFD1F00BC6983 /* AudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E660CC02A3AFD1F00BC6983 /* AudioPlayer.swift */; };
@@ -92,6 +93,7 @@
 		5AC96E112A2E09F10022068C /* RestoreLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreLocation.swift; sourceTree = "<group>"; };
 		5C7925A022DE9B1900B981B2 /* LocationDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationDetails.swift; sourceTree = "<group>"; };
 		5CF01FDD22D92F19004604BC /* ToolsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolsViewController.swift; sourceTree = "<group>"; };
+		DA20260611000000000000A1 /* DeleteOldCyclesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteOldCyclesViewController.swift; sourceTree = "<group>"; };
 		5CFF888A22CAA5B700611F60 /* ActiveLocations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveLocations.swift; sourceTree = "<group>"; };
 		5E4D12732A2776E9002E4D91 /* Slac.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Slac.swift; sourceTree = "<group>"; };
 		5E660CC02A3AFD1F00BC6983 /* AudioPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlayer.swift; sourceTree = "<group>"; };
@@ -318,6 +320,7 @@
 			isa = PBXGroup;
 			children = (
 				5CF01FDD22D92F19004604BC /* ToolsViewController.swift */,
+				DA20260611000000000000A1 /* DeleteOldCyclesViewController.swift */,
 				84571FE4258FE29C009AC936 /* BriefCase.swift */,
 				5CFF888A22CAA5B700611F60 /* ActiveLocations.swift */,
 				5C7925A022DE9B1900B981B2 /* LocationDetails.swift */,
@@ -514,6 +517,7 @@
 				5A5EFD752A306ED500547EB8 /* DIContainer.swift in Sources */,
 				E404C0C52A124558000D2D14 /* Cache.swift in Sources */,
 				5CF01FDE22D92F19004604BC /* ToolsViewController.swift in Sources */,
+				DA20260611000000000000A2 /* DeleteOldCyclesViewController.swift in Sources */,
 				84F477962167173A00A63336 /* LocationApp.xcdatamodeld in Sources */,
 				E465C7C62A1CC9E600B7465B /* UpdateGroups.swift in Sources */,
 				84B58D4D21FD69C80013D5F3 /* UploadToCloud.swift in Sources */,

--- a/LocationApp/LocationApp.xcodeproj/project.pbxproj
+++ b/LocationApp/LocationApp.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		84571FE5258FE29C009AC936 /* BriefCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84571FE4258FE29C009AC936 /* BriefCase.swift */; };
 		845F2E5F221C62E200A48C1A /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845F2E5E221C62E200A48C1A /* Reachability.swift */; };
 		846606C121AA3CA00049814C /* ReadWriteText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846606C021AA3CA00049814C /* ReadWriteText.swift */; };
+		DA20260612000000000000B2 /* CycleCSVExport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA20260612000000000000B1 /* CycleCSVExport.swift */; };
 		846606C321AA5C380049814C /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846606C221AA5C380049814C /* MapViewController.swift */; };
 		84712D582597C874006F31E4 /* Briefcase.csv in Resources */ = {isa = PBXBuildFile; fileRef = 84712D572597C874006F31E4 /* Briefcase.csv */; };
 		84712D622597C9FA006F31E4 /* Version 1.2 Briefcase Flowchart.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 84712D612597C9FA006F31E4 /* Version 1.2 Briefcase Flowchart.pdf */; };
@@ -118,6 +119,7 @@
 		84571FE4258FE29C009AC936 /* BriefCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BriefCase.swift; sourceTree = "<group>"; };
 		845F2E5E221C62E200A48C1A /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
 		846606C021AA3CA00049814C /* ReadWriteText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadWriteText.swift; sourceTree = "<group>"; };
+		DA20260612000000000000B1 /* CycleCSVExport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CycleCSVExport.swift; sourceTree = "<group>"; };
 		846606C221AA5C380049814C /* MapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewController.swift; sourceTree = "<group>"; };
 		846D6B4F2170160E008E003D /* LocationApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = LocationApp.entitlements; sourceTree = "<group>"; };
 		84712D572597C874006F31E4 /* Briefcase.csv */ = {isa = PBXFileReference; lastKnownFileType = text; path = Briefcase.csv; sourceTree = "<group>"; };
@@ -312,6 +314,7 @@
 			isa = PBXGroup;
 			children = (
 				846606C021AA3CA00049814C /* ReadWriteText.swift */,
+				DA20260612000000000000B1 /* CycleCSVExport.swift */,
 			);
 			path = "Text File";
 			sourceTree = "<group>";
@@ -534,6 +537,7 @@
 				5A38B45C2A5D790700489795 /* PhotoViewController.swift in Sources */,
 				449A7E9D271341B2005AF1F7 /* LocationRecordCacheItem.swift in Sources */,
 				846606C121AA3CA00049814C /* ReadWriteText.swift in Sources */,
+				DA20260612000000000000B2 /* CycleCSVExport.swift in Sources */,
 				8487FE3021A8F9C700CC62E8 /* StartupViewController.swift in Sources */,
 				5E4D12742A2776E9002E4D91 /* Slac.swift in Sources */,
 				5A5EFD742A306ED500547EB8 /* SettingsService.swift in Sources */,

--- a/LocationApp/LocationApp/Base.lproj/Main.storyboard
+++ b/LocationApp/LocationApp/Base.lproj/Main.storyboard
@@ -134,8 +134,19 @@
                                     <action selector="resetCacheTouchUp:" destination="M89-R5-CVf" eventType="touchUpInside" id="IUB-yW-ET9"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dOc-Bt-2x2">
+                                <rect key="frame" x="99" y="534" width="230" height="44"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="26"/>
+                                <state key="normal" title="Delete Old Cycles">
+                                    <color key="titleColor" red="0.58072251080000004" green="0.066734083" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="deleteOldCyclesTouchUp:" destination="M89-R5-CVf" eventType="touchUpInside" id="dOc-Ac-2x2"/>
+                                </connections>
+                            </button>
                             <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="12k-op-bR2">
-                                <rect key="frame" x="204" y="534" width="20" height="20"/>
+                                <rect key="frame" x="204" y="608" width="20" height="20"/>
                                 <color key="color" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </activityIndicatorView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="08g-6x-YOH">
@@ -168,7 +179,10 @@
                             <constraint firstItem="RcM-5r-EfG" firstAttribute="leading" secondItem="8cu-87-6eq" secondAttribute="centerX" constant="-90" id="btq-o1-rUX"/>
                             <constraint firstItem="iL3-Xk-1J0" firstAttribute="trailing" secondItem="8cu-87-6eq" secondAttribute="centerX" constant="80" id="dUa-8w-h9i"/>
                             <constraint firstItem="8cu-87-6eq" firstAttribute="bottom" secondItem="3FX-rC-9sw" secondAttribute="bottom" constant="20" id="dVq-SL-gBz"/>
-                            <constraint firstItem="12k-op-bR2" firstAttribute="top" secondItem="RcM-5r-EfG" secondAttribute="bottom" constant="30" id="eAl-df-2zj"/>
+                            <constraint firstItem="dOc-Bt-2x2" firstAttribute="top" secondItem="RcM-5r-EfG" secondAttribute="bottom" constant="30" id="dOc-Tp-2x2"/>
+                            <constraint firstItem="dOc-Bt-2x2" firstAttribute="leading" secondItem="8cu-87-6eq" secondAttribute="centerX" constant="-115" id="dOc-Ld-2x2"/>
+                            <constraint firstItem="dOc-Bt-2x2" firstAttribute="trailing" secondItem="8cu-87-6eq" secondAttribute="centerX" constant="115" id="dOc-Tr-2x2"/>
+                            <constraint firstItem="12k-op-bR2" firstAttribute="top" secondItem="dOc-Bt-2x2" secondAttribute="bottom" constant="30" id="eAl-df-2zj"/>
                             <constraint firstItem="P1C-rk-auY" firstAttribute="top" secondItem="zZL-V9-XtT" secondAttribute="bottom" constant="21" id="fxf-KM-3yN"/>
                             <constraint firstItem="iL3-Xk-1J0" firstAttribute="leading" secondItem="8cu-87-6eq" secondAttribute="centerX" constant="-80" id="g45-4J-oW3"/>
                             <constraint firstItem="3FX-rC-9sw" firstAttribute="centerX" secondItem="Kob-bg-1b1" secondAttribute="centerX" id="gf8-t8-hfs"/>
@@ -183,6 +197,7 @@
                         <outlet property="buildDateLabel" destination="3FX-rC-9sw" id="BDt-Lb-9sw"/>
                         <outlet property="button1" destination="P1C-rk-auY" id="9O8-Dx-vXv"/>
                         <outlet property="button3" destination="iL3-Xk-1J0" id="GOc-1P-xTC"/>
+                        <outlet property="deleteOldCyclesButton" destination="dOc-Bt-2x2" id="dOc-Ou-2x2"/>
                         <outlet property="dosimeters" destination="08g-6x-YOH" id="fLM-zP-XPq"/>
                         <outlet property="resetCacheButton" destination="RcM-5r-EfG" id="fRd-Nn-Tgf"/>
                     </connections>

--- a/LocationApp/LocationApp/Base.lproj/Main.storyboard
+++ b/LocationApp/LocationApp/Base.lproj/Main.storyboard
@@ -179,7 +179,7 @@
                             <constraint firstItem="RcM-5r-EfG" firstAttribute="leading" secondItem="8cu-87-6eq" secondAttribute="centerX" constant="-90" id="btq-o1-rUX"/>
                             <constraint firstItem="iL3-Xk-1J0" firstAttribute="trailing" secondItem="8cu-87-6eq" secondAttribute="centerX" constant="80" id="dUa-8w-h9i"/>
                             <constraint firstItem="8cu-87-6eq" firstAttribute="bottom" secondItem="3FX-rC-9sw" secondAttribute="bottom" constant="20" id="dVq-SL-gBz"/>
-                            <constraint firstItem="dOc-Bt-2x2" firstAttribute="top" secondItem="RcM-5r-EfG" secondAttribute="bottom" constant="30" id="dOc-Tp-2x2"/>
+                            <constraint firstItem="dOc-Bt-2x2" firstAttribute="top" secondItem="RcM-5r-EfG" secondAttribute="bottom" constant="40" id="dOc-Tp-2x2"/>
                             <constraint firstItem="dOc-Bt-2x2" firstAttribute="leading" secondItem="8cu-87-6eq" secondAttribute="centerX" constant="-115" id="dOc-Ld-2x2"/>
                             <constraint firstItem="dOc-Bt-2x2" firstAttribute="trailing" secondItem="8cu-87-6eq" secondAttribute="centerX" constant="115" id="dOc-Tr-2x2"/>
                             <constraint firstItem="12k-op-bR2" firstAttribute="top" secondItem="dOc-Bt-2x2" secondAttribute="bottom" constant="30" id="eAl-df-2zj"/>

--- a/LocationApp/LocationAppTests/LocationAppTests.swift
+++ b/LocationApp/LocationAppTests/LocationAppTests.swift
@@ -597,7 +597,8 @@ class LocationAppTests: XCTestCase {
         let item = try JSONDecoder().decode(LocationRecordCacheItem.self, from: Data(json.utf8))
 
         XCTAssertEqual(CycleCSVExport.row(for: item),
-                       "BLG 006-015,37.4,-122.2,Test Bldg,1,1,D123,1,1-1-2026,06/05/2026,06/10/2026,0,06/05/2026,06/10/2026,rec-1,tester,G1\n")
+                       "BLG 006-015,37.4,-122.2,\"Test Bldg\",1,1,D123,1,1-1-2026,06/05/2026,06/10/2026,0,06/05/2026,06/10/2026,rec-1,tester,\"G1\"\n",
+                       "Description and Report Group cells are quoted so free text can't shift columns")
     }
 
     func test_row_rendersNilOptionalFieldsAsBlankCells() throws {
@@ -605,10 +606,12 @@ class LocationAppTests: XCTestCase {
         // The Tools row builder force-unwrapped dates — this one must not.
         let item = try makeItem(recordName: nil)
 
-        let required = ["Q", "0", "0", "test", "", "0"]
-        let blanks = Array(repeating: "", count: 11)
+        // Description is quoted ("test"); the nil Report Group is quoted-empty
+        // ("\"\""); every other optional renders as a bare empty cell.
+        let fields = ["Q", "0", "0", "\"test\"", "", "0",
+                      "", "", "", "", "", "", "", "", "", "", "\"\""]
         XCTAssertEqual(CycleCSVExport.row(for: item),
-                       (required + blanks).joined(separator: ",") + "\n",
+                       fields.joined(separator: ",") + "\n",
                        "Nil optionals must render as empty cells, never crash or shift columns")
     }
 
@@ -753,5 +756,45 @@ class LocationAppTests: XCTestCase {
     private func removeCacheFileOnDisk() {
         let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
         try? FileManager.default.removeItem(at: caches.appendingPathComponent("cache.txt"))
+    }
+
+    // MARK: - Delete Old Cycles super-user gate (slice 4)
+
+    // The destructive step stays locked unless BOTH interlocks hold: the
+    // all-cycles export was emailed this session AND there is something old to
+    // delete. Either alone must keep the delete button inert.
+    func test_canDelete_requiresBothExportAndEligibleRecords() {
+        XCTAssertTrue(DeleteOldCyclesViewController.canDelete(hasEmailedExport: true, eligibleRecordCount: 5),
+                      "Armed: export sent and old records exist")
+        XCTAssertFalse(DeleteOldCyclesViewController.canDelete(hasEmailedExport: false, eligibleRecordCount: 5),
+                       "Locked: export not yet emailed")
+        XCTAssertFalse(DeleteOldCyclesViewController.canDelete(hasEmailedExport: true, eligibleRecordCount: 0),
+                       "Locked: nothing old to delete")
+        XCTAssertFalse(DeleteOldCyclesViewController.canDelete(hasEmailedExport: false, eligibleRecordCount: 0),
+                       "Locked: neither interlock satisfied")
+    }
+
+    // A negative count can never arm the gate (defensive — eligibleTotal can't
+    // go negative today, but the gate must not depend on that).
+    func test_canDelete_falseForNonPositiveCount() {
+        XCTAssertFalse(DeleteOldCyclesViewController.canDelete(hasEmailedExport: true, eligibleRecordCount: -1))
+    }
+
+    // The type-DELETE confirmation must match EXACTLY: uppercase, no leading or
+    // trailing whitespace, no near-misses. This is the last guard before a
+    // permanent CloudKit deletion, so the rule is pinned by a test.
+    func test_deleteIsConfirmed_requiresExactUppercaseDELETE() {
+        XCTAssertTrue(DeleteOldCyclesViewController.deleteIsConfirmed(byTyping: "DELETE"))
+
+        for rejected in ["delete", "Delete", "DELETE ", " DELETE", " DELETE ", "DELET", "DELETED", "", nil] {
+            XCTAssertFalse(DeleteOldCyclesViewController.deleteIsConfirmed(byTyping: rejected),
+                           "\(String(describing: rejected)) must not confirm a deletion")
+        }
+    }
+
+    // The forced export must address the SLAC records-management group; a typo
+    // here would silently send the audit trail to the wrong place.
+    func test_exportRecipient_isTheRecordsManagementGroup() {
+        XCTAssertEqual(DeleteOldCyclesViewController.exportRecipient, "esh-DREP@slac.stanford.edu")
     }
 }

--- a/LocationApp/LocationAppTests/LocationAppTests.swift
+++ b/LocationApp/LocationAppTests/LocationAppTests.swift
@@ -572,6 +572,93 @@ class LocationAppTests: XCTestCase {
         }
     }
 
+    // MARK: - CycleCSVExport (the forced all-cycles export before deletion)
+
+    func test_csvHeader_matchesTheToolsExportColumns() {
+        XCTAssertEqual(CycleCSVExport.header,
+                       "LocationID (QRCode),Latitude,Longitude,Description,Moderator (0/1),Active (0/1),Dosimeter,Collected Flag (0/1),Wear Period,System_Date Deployed,System_Date Collected,Mismatch (0/1), my_Date Deployed, my_Date Collected, recordID, ModifiedBy, Report Group\n",
+                       "Header must stay column-compatible with the Tools email export")
+    }
+
+    func test_row_rendersEveryFieldInColumnOrder() throws {
+        let deployed = try XCTUnwrap(noonLocal(year: 2026, month: 6, day: 5))
+        let modified = try XCTUnwrap(noonLocal(year: 2026, month: 6, day: 10))
+        let json = """
+        { "QRCode": "BLG 006-015", "latitude": "37.4", "longitude": "-122.2", \
+        "locdescription": "Test Bldg", "active": 1, "dosinumber": "D123", \
+        "collectedFlag": 1, "cycleDate": "1-1-2026", "mismatch": 0, "moderator": 1, \
+        "creationDate": \(deployed.timeIntervalSinceReferenceDate), \
+        "createdDate": \(deployed.timeIntervalSinceReferenceDate), \
+        "modifiedDate": \(modified.timeIntervalSinceReferenceDate), \
+        "modificationDate": \(modified.timeIntervalSinceReferenceDate), \
+        "recordName": "rec-1", "modifiedBy": "tester", "reportGroup": "G1", \
+        "hasPhoto": false }
+        """
+        let item = try JSONDecoder().decode(LocationRecordCacheItem.self, from: Data(json.utf8))
+
+        XCTAssertEqual(CycleCSVExport.row(for: item),
+                       "BLG 006-015,37.4,-122.2,Test Bldg,1,1,D123,1,1-1-2026,06/05/2026,06/10/2026,0,06/05/2026,06/10/2026,rec-1,tester,G1\n")
+    }
+
+    func test_row_rendersNilOptionalFieldsAsBlankCells() throws {
+        // makeItem populates only the required fields; every optional is nil.
+        // The Tools row builder force-unwrapped dates — this one must not.
+        let item = try makeItem(recordName: nil)
+
+        let required = ["Q", "0", "0", "test", "", "0"]
+        let blanks = Array(repeating: "", count: 11)
+        XCTAssertEqual(CycleCSVExport.row(for: item),
+                       (required + blanks).joined(separator: ",") + "\n",
+                       "Nil optionals must render as empty cells, never crash or shift columns")
+    }
+
+    func test_csvText_sortsByQRCodeThenNewestDeployFirst() throws {
+        let later = try makeItem(recordName: "rB", QRCode: "BLG 044")
+        let olderDeploy = try makeItem(recordName: "rA-old", QRCode: "BLG 003", createdDate: 700_000_000)
+        let newerDeploy = try makeItem(recordName: "rA-new", QRCode: "BLG 003", createdDate: 800_000_000)
+
+        let text = CycleCSVExport.csvText(for: [later, olderDeploy, newerDeploy])
+        let lines = text.components(separatedBy: "\n")
+
+        XCTAssertTrue(lines[1].contains("rA-new"), "QRCode ascending, newest deploy first within a QRCode")
+        XCTAssertTrue(lines[2].contains("rA-old"))
+        XCTAssertTrue(lines[3].contains("rB"))
+    }
+
+    func test_csvText_includesDeletableRecordsTheToolsExportWouldDrop() throws {
+        // A record with an old cycle but a nil createdDate is delete-eligible,
+        // yet the Tools export filters on createdDate != nil and would omit it.
+        // The pre-delete audit export must be a superset of anything deletable.
+        let protectedCycles = RecordsUpdate.getLastCycles(cycles: 4)
+        let fifthCycleBack = RecordsUpdate.generatePriorCycleDate(cycleDate: protectedCycles.last!)
+        let item = try makeItem(recordName: "ghost-record", cycleDate: fifthCycleBack)
+
+        XCTAssertTrue(LocationsCK.isEligibleForCycleDeletion(item: item, protectedCycles: protectedCycles),
+                      "Precondition: this record must be deletable for the test to mean anything")
+        XCTAssertTrue(CycleCSVExport.csvText(for: [item]).contains("ghost-record"),
+                      "Every deletable record must appear in the audit export")
+    }
+
+    func test_csvText_beginsWithHeaderAndEndsWithEndOfFileMarker() throws {
+        let text = CycleCSVExport.csvText(for: [try makeItem(recordName: "r1")])
+
+        XCTAssertTrue(text.hasPrefix(CycleCSVExport.header))
+        XCTAssertTrue(text.hasSuffix("End of File\n"))
+        XCTAssertEqual(text.components(separatedBy: "\n").count, 4,
+                       "Header + one row + End of File + the trailing newline's empty component")
+    }
+
+    /// Noon local time avoids DST-edge surprises when the exporter formats
+    /// the date back in the current calendar.
+    private func noonLocal(year: Int, month: Int, day: Int) -> Date? {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = 12
+        return Calendar.current.date(from: components)
+    }
+
     // MARK: - Fixtures
 
     /// A Location CKRecord with every field `init?(withRecord:)` needs, minus the
@@ -625,9 +712,9 @@ class LocationAppTests: XCTestCase {
         XCTAssertEqual(original.collectedFlag, 0, "copy must not alias the original")
     }
 
-    private func makeItem(recordName: String?, locdescription: String = "test", hasPhoto: Bool = false, cycleDate: String? = nil, createdDate: Double? = nil) throws -> LocationRecordCacheItem {
+    private func makeItem(recordName: String?, QRCode: String = "Q", locdescription: String = "test", hasPhoto: Bool = false, cycleDate: String? = nil, createdDate: Double? = nil) throws -> LocationRecordCacheItem {
         var fields: [String] = [
-            "\"QRCode\": \"Q\"",
+            "\"QRCode\": \"\(QRCode)\"",
             "\"latitude\": \"0\"",
             "\"longitude\": \"0\"",
             "\"locdescription\": \"\(locdescription)\"",

--- a/LocationApp/LocationAppTests/LocationAppTests.swift
+++ b/LocationApp/LocationAppTests/LocationAppTests.swift
@@ -429,12 +429,45 @@ class LocationAppTests: XCTestCase {
         XCTAssertEqual(reloaded.defaultLongitude, -122.5)
     }
 
-    // MARK: - Cache.remove (SOW 2.2: super-user delete, slice 1)
+    // MARK: - Settings super-user passcode (delete-old-cycles gate)
 
-    // deleteOldCycleRecords drops confirmed-deleted records from the cache via
-    // remove(recordNames:). It must prune BOTH the locations array and the
-    // pending-changes queue (else a queued upload resurrects a deleted record
-    // on the next sync) and rebuild the transient index.
+    // Same decode-compatibility invariant as the coordinate fields: cached
+    // Settings JSON written before the passcode field existed must still
+    // decode, with the accessor falling back to the initial passcode.
+    func test_settingsDecode_withoutPasscodeField_succeedsAndUsesFallback() throws {
+        let oldFormat = #"{"dosimeterMinimumLength": 11, "dosimeterMaximumLength": 11}"#
+
+        let settings = try JSONDecoder().decode(Settings.self, from: Data(oldFormat.utf8))
+
+        XCTAssertNil(settings.superUserPasscode)
+        XCTAssertEqual(settings.superUserPasscodeValue, 4299)
+    }
+
+    func test_settingsDecode_withPasscodeField_usesConfiguredValue() throws {
+        // A rotated passcode set on the CloudKit Settings record must win over
+        // the built-in initial value.
+        let configured = #"{"dosimeterMinimumLength": 11, "dosimeterMaximumLength": 11, "superUserPasscode": 8121}"#
+
+        let settings = try JSONDecoder().decode(Settings.self, from: Data(configured.utf8))
+
+        XCTAssertEqual(settings.superUserPasscodeValue, 8121)
+    }
+
+    func test_settings_roundTripPreservesPasscode() throws {
+        let settings = Settings()
+        settings.superUserPasscode = 8121
+
+        let data = try JSONEncoder().encode(settings)
+        let reloaded = try JSONDecoder().decode(Settings.self, from: data)
+
+        XCTAssertEqual(reloaded.superUserPasscode, 8121)
+    }
+
+    // MARK: - Cache.remove (super-user delete)
+
+    // remove(recordNames:) must prune BOTH the locations array and the
+    // pending-changes queue (else a queued upload resurrects a deleted
+    // record on the next sync) and rebuild the transient index.
 
     func test_remove_removesNamedLocationsAndReportsCount() throws {
         let cache = Cache()
@@ -489,12 +522,11 @@ class LocationAppTests: XCTestCase {
         XCTAssertEqual(cache.locations.count, 1, "The nil-recordName item must survive; it can't match any name")
     }
 
-    // MARK: - isEligibleForCycleDeletion (SOW 2.2 safety invariant)
+    // MARK: - isEligibleForCycleDeletion (safety invariant)
 
-    // The acceptance criterion is absolute: records from the most recent 4
-    // cycles cannot be deleted even if explicitly requested. This pure decision
-    // is the single place that invariant lives — deleteOldCycleRecords
-    // recomputes eligibility itself rather than trusting the caller's list.
+    // Records from the most recent 4 cycles can never be deleted, even if
+    // explicitly requested. deleteOldCycleRecords recomputes eligibility
+    // itself rather than trusting the caller's list.
 
     func test_eligible_falseWhenCycleDateNil() throws {
         let item = try makeItem(recordName: "r1")

--- a/LocationApp/LocationAppTests/LocationAppTests.swift
+++ b/LocationApp/LocationAppTests/LocationAppTests.swift
@@ -429,6 +429,117 @@ class LocationAppTests: XCTestCase {
         XCTAssertEqual(reloaded.defaultLongitude, -122.5)
     }
 
+    // MARK: - Cache.remove (SOW 2.2: super-user delete, slice 1)
+
+    // deleteOldCycleRecords drops confirmed-deleted records from the cache via
+    // remove(recordNames:). It must prune BOTH the locations array and the
+    // pending-changes queue (else a queued upload resurrects a deleted record
+    // on the next sync) and rebuild the transient index.
+
+    func test_remove_removesNamedLocationsAndReportsCount() throws {
+        let cache = Cache()
+        cache.add(try makeItem(recordName: "r1"))
+        cache.add(try makeItem(recordName: "r2"))
+        cache.add(try makeItem(recordName: "r3"))
+
+        let removed = cache.remove(recordNames: ["r1", "r3"])
+
+        XCTAssertEqual(removed, 2)
+        XCTAssertEqual(cache.locations.map { $0.recordName }, ["r2"])
+    }
+
+    func test_remove_prunesPendingChangesForDeletedRecords() throws {
+        let cache = Cache()
+        let item = try makeItem(recordName: "r1")
+        cache.add(item)
+        cache.addChange(item)
+        cache.addChange(try makeItem(recordName: "r2"))
+
+        cache.remove(recordNames: ["r1"])
+
+        XCTAssertEqual(cache.changes.map { $0.recordName }, ["r2"],
+                       "A deleted record's queued edit must be pruned, or the next sync re-uploads (resurrects) it")
+    }
+
+    func test_remove_rebuildsIndexSoLookupMissesAndReAddAppendsFresh() throws {
+        let cache = Cache()
+        cache.add(try makeItem(recordName: "r1", locdescription: "before"))
+        cache.add(try makeItem(recordName: "r2"))
+
+        cache.remove(recordNames: ["r1"])
+
+        XCTAssertNil(cache.location(forRecordName: "r1"),
+                     "Lookup must miss after removal, not return a neighbouring record via a stale index slot")
+        XCTAssertEqual(cache.location(forRecordName: "r2")?.recordName, "r2",
+                       "Surviving records must stay reachable through the rebuilt index")
+
+        cache.add(try makeItem(recordName: "r1", locdescription: "after"))
+        XCTAssertEqual(cache.locations.count, 2)
+        XCTAssertEqual(cache.location(forRecordName: "r1")?.locdescription, "after")
+    }
+
+    func test_remove_leavesNilRecordNameItemsAndUnknownNamesAlone() throws {
+        let cache = Cache()
+        cache.add(try makeItem(recordName: nil))
+        cache.add(try makeItem(recordName: "r1"))
+
+        let removed = cache.remove(recordNames: ["r1", "never-existed"])
+
+        XCTAssertEqual(removed, 1)
+        XCTAssertEqual(cache.locations.count, 1, "The nil-recordName item must survive; it can't match any name")
+    }
+
+    // MARK: - isEligibleForCycleDeletion (SOW 2.2 safety invariant)
+
+    // The acceptance criterion is absolute: records from the most recent 4
+    // cycles cannot be deleted even if explicitly requested. This pure decision
+    // is the single place that invariant lives — deleteOldCycleRecords
+    // recomputes eligibility itself rather than trusting the caller's list.
+
+    func test_eligible_falseWhenCycleDateNil() throws {
+        let item = try makeItem(recordName: "r1")
+
+        XCTAssertFalse(LocationsCK.isEligibleForCycleDeletion(item: item, protectedCycles: ["1-1-2026"]),
+                       "A record without a cycleDate can't be proven old; the conservative answer is keep")
+    }
+
+    func test_eligible_falseForEveryProtectedCycle() throws {
+        let protectedCycles = RecordsUpdate.getLastCycles(cycles: 4)
+
+        for cycle in protectedCycles {
+            let item = try makeItem(recordName: "r1", cycleDate: cycle)
+            XCTAssertFalse(LocationsCK.isEligibleForCycleDeletion(item: item, protectedCycles: protectedCycles),
+                           "Cycle \(cycle) is within the most recent 4 and must never be deletable")
+        }
+    }
+
+    func test_eligible_trueForCycleOlderThanProtectedWindow() throws {
+        let protectedCycles = RecordsUpdate.getLastCycles(cycles: 4)
+        let fifthCycleBack = RecordsUpdate.generatePriorCycleDate(cycleDate: protectedCycles.last!)
+        let item = try makeItem(recordName: "r1", cycleDate: fifthCycleBack)
+
+        XCTAssertTrue(LocationsCK.isEligibleForCycleDeletion(item: item, protectedCycles: protectedCycles),
+                      "The 5th cycle back is outside the protected window and must be eligible")
+    }
+
+    // MARK: - getLastCycles (the protected-window source)
+
+    func test_getLastCycles_returnsContiguousCyclesNewestFirst() {
+        let cycles = RecordsUpdate.getLastCycles(cycles: 4)
+
+        XCTAssertEqual(cycles.count, 4)
+        XCTAssertEqual(cycles[0], RecordsUpdate.generateCycleDate(),
+                       "The newest entry must be the current cycle")
+        for cycle in cycles {
+            XCTAssertTrue(cycle.hasPrefix("1-1-") || cycle.hasPrefix("7-1-"),
+                          "Cycle keys use the exact \"M-1-YYYY\" format with M of 1 or 7; got \(cycle)")
+        }
+        for index in 1..<cycles.count {
+            XCTAssertEqual(cycles[index], RecordsUpdate.generatePriorCycleDate(cycleDate: cycles[index - 1]),
+                           "Each entry must be exactly one 6-month cycle older than the previous")
+        }
+    }
+
     // MARK: - Fixtures
 
     /// A Location CKRecord with every field `init?(withRecord:)` needs, minus the

--- a/LocationApp/Text File/CycleCSVExport.swift
+++ b/LocationApp/Text File/CycleCSVExport.swift
@@ -1,0 +1,63 @@
+//
+//  CycleCSVExport.swift
+//  LocationApp
+//
+//  Created by Daniel Spady on 6/12/26.
+//
+
+import Foundation
+
+//MARK:  All-cycles CSV export
+
+//Builds the CSV attached to the export email required before deleting old
+//cycles. Same columns and ordering as the Tools email export, but it covers
+//every cached record and renders missing fields as blank cells, so the file
+//is a complete audit copy of anything a delete could touch.
+struct CycleCSVExport {
+
+    static let header = "LocationID (QRCode),Latitude,Longitude,Description,Moderator (0/1),Active (0/1),Dosimeter,Collected Flag (0/1),Wear Period,System_Date Deployed,System_Date Collected,Mismatch (0/1), my_Date Deployed, my_Date Collected, recordID, ModifiedBy, Report Group\n"
+
+    //Whole-file build: header, one row per record (QRCode ascending, newest
+    //deploy first within a QRCode — same ordering as the Tools export), then
+    //the End of File marker line.
+    static func csvText(for items: [LocationRecordCacheItem]) -> String {
+        let sorted = items.sorted {
+            if $0.QRCode == $1.QRCode {
+                return $0.createdDateForSort > $1.createdDateForSort
+            }
+            return $0.QRCode < $1.QRCode
+        }
+        var text = header
+        for item in sorted {
+            text.append(row(for: item))
+        }
+        text.append("End of File\n")
+        return text
+    }
+
+    //One CSV line per record. Optional fields become empty cells — no
+    //force-unwraps, so the export survives any record the cache can hold.
+    static func row(for item: LocationRecordCacheItem) -> String {
+        let moderator = item.moderator.map { String($0) } ?? ""
+        let dosimeter = item.dosinumber ?? ""
+        let collected = item.collectedFlag.map { String($0) } ?? ""
+        let cycle = item.cycleDate ?? ""
+        let mismatch = item.mismatch.map { String($0) } ?? ""
+        let recordID = item.recordName ?? ""
+        let modifiedBy = item.modifiedBy ?? ""
+        let group = item.reportGroup ?? ""
+
+        return "\(item.QRCode),\(item.latitude),\(item.longitude),\(item.locdescription),\(moderator),\(item.active),\(dosimeter),\(collected),\(cycle),\(format(item.creationDate)),\(format(item.modificationDate)),\(mismatch),\(format(item.createdDate)),\(format(item.modifiedDate)),\(recordID),\(modifiedBy),\(group)\n"
+    }
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MM/dd/yyyy"
+        return formatter
+    }()
+
+    private static func format(_ date: Date?) -> String {
+        guard let date = date else { return "" }
+        return dateFormatter.string(from: date)
+    }
+}

--- a/LocationApp/Text File/CycleCSVExport.swift
+++ b/LocationApp/Text File/CycleCSVExport.swift
@@ -47,7 +47,13 @@ struct CycleCSVExport {
         let modifiedBy = item.modifiedBy ?? ""
         let group = item.reportGroup ?? ""
 
-        return "\(item.QRCode),\(item.latitude),\(item.longitude),\(item.locdescription),\(moderator),\(item.active),\(dosimeter),\(collected),\(cycle),\(format(item.creationDate)),\(format(item.modificationDate)),\(mismatch),\(format(item.createdDate)),\(format(item.modifiedDate)),\(recordID),\(modifiedBy),\(group)\n"
+        return "\(item.QRCode),\(item.latitude),\(item.longitude),\(quoted(item.locdescription)),\(moderator),\(item.active),\(dosimeter),\(collected),\(cycle),\(format(item.creationDate)),\(format(item.modificationDate)),\(mismatch),\(format(item.createdDate)),\(format(item.modifiedDate)),\(recordID),\(modifiedBy),\(quoted(group))\n"
+    }
+
+    //Wraps a free-text cell in quotes so an embedded comma or newline can't
+    //shift columns; any embedded quote is doubled, per RFC 4180.
+    private static func quoted(_ value: String) -> String {
+        return "\"\(value.replacingOccurrences(of: "\"", with: "\"\""))\""
     }
 
     private static let dateFormatter: DateFormatter = {

--- a/LocationApp/Utility View/DeleteOldCyclesViewController.swift
+++ b/LocationApp/Utility View/DeleteOldCyclesViewController.swift
@@ -1,0 +1,150 @@
+//
+//  DeleteOldCyclesViewController.swift
+//  LocationApp
+//
+//  Created by Daniel Spady on 6/11/26.
+//
+
+import Foundation
+import UIKit
+
+//MARK:  Class
+
+//Super-user admin screen, reached from Tools behind the passcode gate.
+//Read-only preview of what a delete would affect: the latest cycles are
+//listed as protected, older cycles with their record counts.
+class DeleteOldCyclesViewController: UIViewController {
+
+    let locations = container.locations
+
+    //The latest 4 cycles (2 years) are protected absolutely.
+    //deleteOldCycleRecords recomputes this itself — this only drives the preview.
+    static let cyclesToKeep = 4
+
+    private let tableView = UITableView(frame: .zero, style: .insetGrouped)
+
+    private var protectedCycles: [String] = []
+    //Older cycles that still have records, newest first, with per-cycle counts.
+    private var eligibleCycleCounts: [(cycle: String, count: Int)] = []
+    private var eligibleTotal = 0
+
+    //MARK:  View lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = "Delete Old Cycles"
+        view.backgroundColor = .systemBackground
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done,
+                                                            target: self,
+                                                            action: #selector(done))
+
+        tableView.dataSource = self
+        tableView.allowsSelection = false
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(tableView)
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+
+        reloadPreview()
+    }
+
+    @objc func done() {
+        self.dismiss(animated: true, completion: nil)
+    }
+
+    //MARK:  Preview
+
+    func reloadPreview() {
+        protectedCycles = RecordsUpdate.getLastCycles(cycles: DeleteOldCyclesViewController.cyclesToKeep)
+
+        let eligible = locations.eligibleOldCycleRecords(keepingCycles: DeleteOldCyclesViewController.cyclesToKeep)
+        eligibleTotal = eligible.count
+
+        var counts: [String: Int] = [:]
+        for item in eligible {
+            //eligibleOldCycleRecords never returns a nil cycleDate, but stay
+            //defensive — an unexpected record lands in its own bucket rather
+            //than crashing the admin screen.
+            let cycle = item.cycleDate ?? "No cycle date"
+            counts[cycle, default: 0] += 1
+        }
+        eligibleCycleCounts = counts
+            .map { (cycle: $0.key, count: $0.value) }
+            .sorted { sortKey(for: $0.cycle) > sortKey(for: $1.cycle) }
+
+        print("Super-user screen: \(eligibleTotal) records in \(eligibleCycleCounts.count) old cycles eligible; protected cycles: \(protectedCycles)")
+        tableView.reloadData()
+    }
+
+    //Orders "M-1-YYYY" cycle keys chronologically (year first, then month).
+    //A plain string sort would put "7-1-2024" after "1-1-2025".
+    private func sortKey(for cycle: String) -> Int {
+        let parts = cycle.split(separator: "-")
+        guard parts.count == 3,
+              let month = Int(parts[0]),
+              let year = Int(parts[2]) else { return Int.min }
+        return year * 100 + month
+    }
+}
+
+//MARK:  Table data source
+
+extension DeleteOldCyclesViewController: UITableViewDataSource {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 2
+    }
+
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        if section == 0 {
+            return "Protected — latest \(DeleteOldCyclesViewController.cyclesToKeep) cycles"
+        }
+        return "Older cycles eligible for deletion"
+    }
+
+    func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        if section == 0 {
+            return "Records in these cycles can never be deleted."
+        }
+        if eligibleTotal == 0 {
+            return "No records older than the protected cycles were found."
+        }
+        return "\(eligibleTotal) records total. Deleting requires a fresh export of all cycles first — that step arrives in the next update."
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        if section == 0 {
+            return protectedCycles.count
+        }
+        return max(eligibleCycleCounts.count, 1)
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "cycleCell")
+            ?? UITableViewCell(style: .value1, reuseIdentifier: "cycleCell")
+
+        if indexPath.section == 0 {
+            cell.textLabel?.text = protectedCycles[indexPath.row]
+            cell.detailTextLabel?.text = "Protected"
+            cell.detailTextLabel?.textColor = .secondaryLabel
+            return cell
+        }
+
+        guard !eligibleCycleCounts.isEmpty else {
+            cell.textLabel?.text = "Nothing to delete"
+            cell.detailTextLabel?.text = nil
+            return cell
+        }
+
+        let entry = eligibleCycleCounts[indexPath.row]
+        cell.textLabel?.text = entry.cycle
+        cell.detailTextLabel?.text = "\(entry.count) record\(entry.count == 1 ? "" : "s")"
+        cell.detailTextLabel?.textColor = .secondaryLabel
+        return cell
+    }
+}

--- a/LocationApp/Utility View/DeleteOldCyclesViewController.swift
+++ b/LocationApp/Utility View/DeleteOldCyclesViewController.swift
@@ -13,9 +13,8 @@ import AVFoundation
 //MARK:  Class
 
 //Super-user admin screen, reached from Tools behind the passcode gate.
-//Shows what a delete would affect (protected cycles, older cycles with
-//record counts) and the required first step: emailing a full all-cycles
-//export. Deleting stays locked until that export has actually been sent.
+//Shows what a delete would affect, then forces an all-cycles export first:
+//deleting stays locked until that export has actually been sent.
 class DeleteOldCyclesViewController: UIViewController {
 
     let locations = container.locations
@@ -23,6 +22,9 @@ class DeleteOldCyclesViewController: UIViewController {
     //The latest 4 cycles (2 years) are protected absolutely.
     //deleteOldCycleRecords recomputes this itself — this only drives the preview.
     static let cyclesToKeep = 4
+
+    //The records-management group the all-cycles export must go to.
+    static let exportRecipient = "esh-DREP@slac.stanford.edu"
 
     private let tableView = UITableView(frame: .zero, style: .insetGrouped)
 
@@ -35,6 +37,13 @@ class DeleteOldCyclesViewController: UIViewController {
     //delete step (next update) keys off this, so cancel/draft don't count.
     private(set) var hasEmailedExport = false
     private var exportedRecordCount = 0
+
+    //Held while a delete is running so progress callbacks can update its
+    //message; also guards against starting a second delete on top of one.
+    private var deleteProgressAlert: UIAlertController?
+
+    //Watches the type-DELETE field; removed when the confirm alert closes.
+    private var deleteConfirmObserver: NSObjectProtocol?
 
     //MARK:  View lifecycle
 
@@ -119,12 +128,135 @@ class DeleteOldCyclesViewController: UIViewController {
         let protectedList = protectedCycles.joined(separator: ", ")
         let mail = MFMailComposeViewController()
         mail.mailComposeDelegate = self
+        mail.setToRecipients([DeleteOldCyclesViewController.exportRecipient])
         mail.setSubject("Area Dosimeter Data - Full Export (All Cycles)")
         mail.setMessageBody("Attached is a full export of all \(items.count) location records across all cycles, generated before deleting old cycles. Protected cycles: \(protectedList). Eligible for deletion: \(eligibleTotal) records in \(eligibleCycleCounts.count) older cycles.", isHTML: false)
         mail.addAttachmentData(Data(csv.utf8), mimeType: "text/csv", fileName: "Dosi_Data_All_Cycles.csv")
         present(mail, animated: true)
 
         print("Delete Old Cycles: composing all-cycles export, \(items.count) records")
+    }
+
+    //MARK:  Delete step
+
+    //Both interlocks for the destructive step: export emailed this session and
+    //something old to delete. Data layer recomputes eligibility too, so this is
+    //the UI gate. Static + pure so LocationAppTests can drive it offline.
+    static func canDelete(hasEmailedExport: Bool, eligibleRecordCount: Int) -> Bool {
+        return hasEmailedExport && eligibleRecordCount > 0
+    }
+
+    //Text typed into the confirmation field must read exactly "DELETE" — no
+    //surrounding whitespace, no case folding — so a stray tap can't wipe old
+    //cycles. Pure so the exact-match rule is locked down by a unit test.
+    static func deleteIsConfirmed(byTyping text: String?) -> Bool {
+        return text == "DELETE"
+    }
+
+    //Whether the destructive Step 2 row should act, for the current UI state.
+    var canDelete: Bool {
+        return DeleteOldCyclesViewController.canDelete(hasEmailedExport: hasEmailedExport,
+                                                       eligibleRecordCount: eligibleTotal)
+    }
+
+    //Type-DELETE confirmation. The destructive action stays disabled until the
+    //field reads exactly "DELETE", so a stray tap can't wipe old cycles.
+    func confirmDelete() {
+        guard canDelete else { return }
+
+        let recordWord = eligibleTotal == 1 ? "Record" : "Records"
+        let cycleCount = eligibleCycleCounts.count
+        let cycleWord = cycleCount == 1 ? "cycle" : "cycles"
+        let alert = UIAlertController(title: "Delete \(eligibleTotal) Old \(recordWord)?",
+                                      message: "This permanently removes every record in the \(cycleCount) older \(cycleWord) from CloudKit. It cannot be undone. Type DELETE to confirm.",
+                                      preferredStyle: .alert)
+        alert.addTextField { field in
+            field.autocapitalizationType = .allCharacters
+            field.autocorrectionType = .no
+        }
+
+        let deleteAction = UIAlertAction(title: "Delete", style: .destructive) { [weak self, weak alert] _ in
+            self?.stopWatchingDeleteField()
+            guard DeleteOldCyclesViewController.deleteIsConfirmed(byTyping: alert?.textFields?.first?.text) else { return }
+            self?.runDelete()
+        }
+        deleteAction.isEnabled = false
+        alert.addAction(deleteAction)
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel) { [weak self] _ in
+            self?.stopWatchingDeleteField()
+        })
+
+        //Enable Delete only on an exact match — no trimming, no case folding.
+        deleteConfirmObserver = NotificationCenter.default.addObserver(
+            forName: UITextField.textDidChangeNotification,
+            object: alert.textFields?.first,
+            queue: .main) { [weak deleteAction] notification in
+            let text = (notification.object as? UITextField)?.text
+            deleteAction?.isEnabled = DeleteOldCyclesViewController.deleteIsConfirmed(byTyping: text)
+        }
+
+        present(alert, animated: true)
+    }
+
+    private func stopWatchingDeleteField() {
+        if let observer = deleteConfirmObserver {
+            NotificationCenter.default.removeObserver(observer)
+            deleteConfirmObserver = nil
+        }
+    }
+
+    private func runDelete() {
+        //One delete at a time: a live progress alert means one is already
+        //running, so ignore any second trigger.
+        guard deleteProgressAlert == nil else { return }
+
+        //Non-dismissible progress alert. The message stays generic until the
+        //first per-batch callback supplies the data layer's own total, so it
+        //never shows a stale count from the last preview.
+        let progressAlert = UIAlertController(title: "Deleting…",
+                                              message: "Preparing…",
+                                              preferredStyle: .alert)
+        deleteProgressAlert = progressAlert
+        present(progressAlert, animated: true)
+
+        print("Delete Old Cycles: starting delete of \(eligibleTotal) eligible records")
+
+        locations.deleteOldCycleRecords(keepingCycles: DeleteOldCyclesViewController.cyclesToKeep,
+                                        progress: { [weak self] deleted, total in
+            self?.deleteProgressAlert?.message = "\(deleted) of \(total) deleted"
+        }, completion: { [weak self] deleted, error in
+            self?.finishDelete(deleted: deleted, error: error)
+        })
+    }
+
+    private func finishDelete(deleted: Int, error: Error?) {
+        //Refresh counts first so the preview (and the canDelete gate) reflect
+        //what's actually left after the deletion.
+        reloadPreview()
+
+        let result: UIAlertController
+        if let error = error {
+            print("Delete Old Cycles: finished with error after \(deleted) deletions: \(error.localizedDescription)")
+            result = UIAlertController(title: "Deletion Stopped",
+                                       message: "\(deleted) record\(deleted == 1 ? "" : "s") deleted before stopping.\n\n\(error.localizedDescription)",
+                                       preferredStyle: .alert)
+        } else {
+            print("Delete Old Cycles: finished, \(deleted) records deleted")
+            result = UIAlertController(title: "Deletion Complete",
+                                       message: "\(deleted) old-cycle record\(deleted == 1 ? "" : "s") deleted.",
+                                       preferredStyle: .alert)
+        }
+        result.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+
+        //Tear down the progress alert, then surface the outcome.
+        if let progress = deleteProgressAlert {
+            deleteProgressAlert = nil
+            progress.dismiss(animated: true) { [weak self] in
+                self?.present(result, animated: true)
+            }
+        } else {
+            present(result, animated: true)
+        }
     }
 }
 
@@ -161,9 +293,9 @@ extension DeleteOldCyclesViewController: MFMailComposeViewControllerDelegate {
 
 extension DeleteOldCyclesViewController: UITableViewDataSource {
 
-    //Sections: 0 protected cycles, 1 eligible cycles, 2 the export step.
+    //Sections: 0 protected cycles, 1 eligible cycles, 2 export step, 3 delete step.
     func numberOfSections(in tableView: UITableView) -> Int {
-        return 3
+        return 4
     }
 
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
@@ -173,7 +305,10 @@ extension DeleteOldCyclesViewController: UITableViewDataSource {
         if section == 1 {
             return "Older cycles eligible for deletion"
         }
-        return "Step 1 — Export all cycles"
+        if section == 2 {
+            return "Step 1 — Export all cycles"
+        }
+        return "Step 2 — Delete old cycles"
     }
 
     func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
@@ -186,10 +321,19 @@ extension DeleteOldCyclesViewController: UITableViewDataSource {
             }
             return "\(eligibleTotal) records total. Deleting requires a fresh export of all cycles first — Step 1 below."
         }
-        if hasEmailedExport {
-            return "Export emailed — \(exportedRecordCount) records attached. The delete step arrives in the next update."
+        if section == 2 {
+            if hasEmailedExport {
+                return "Export emailed — \(exportedRecordCount) records attached. Step 2 is now unlocked."
+            }
+            return "Emails a CSV of every record in every cycle to \(DeleteOldCyclesViewController.exportRecipient). Required before anything can be deleted."
         }
-        return "Emails a CSV of every record in every cycle. Required before anything can be deleted."
+        if !hasEmailedExport {
+            return "Email the export above first — this step stays locked until it has been sent."
+        }
+        if eligibleTotal == 0 {
+            return "Nothing to delete."
+        }
+        return "Permanently deletes \(eligibleTotal) record\(eligibleTotal == 1 ? "" : "s") in \(eligibleCycleCounts.count) older cycles from CloudKit. This cannot be undone."
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -199,6 +343,7 @@ extension DeleteOldCyclesViewController: UITableViewDataSource {
         if section == 1 {
             return max(eligibleCycleCounts.count, 1)
         }
+        //Sections 2 (export) and 3 (delete) are single action rows.
         return 1
     }
 
@@ -224,6 +369,17 @@ extension DeleteOldCyclesViewController: UITableViewDataSource {
             return cell
         }
 
+        if indexPath.section == 3 {
+            cell.textLabel?.text = "Delete \(eligibleTotal) Old Record\(eligibleTotal == 1 ? "" : "s")"
+            //Destructive red only when armed; muted while locked so it doesn't
+            //read as tappable before the export has been sent.
+            cell.textLabel?.textColor = canDelete ? .systemRed : .secondaryLabel
+            cell.detailTextLabel?.text = canDelete ? nil : "Locked"
+            cell.detailTextLabel?.textColor = .secondaryLabel
+            cell.selectionStyle = canDelete ? .default : .none
+            return cell
+        }
+
         guard !eligibleCycleCounts.isEmpty else {
             cell.textLabel?.text = "Nothing to delete"
             cell.detailTextLabel?.text = nil
@@ -242,13 +398,20 @@ extension DeleteOldCyclesViewController: UITableViewDataSource {
 
 extension DeleteOldCyclesViewController: UITableViewDelegate {
 
-    //Only the export row is actionable; the cycle lists stay read-only.
+    //Only the two action rows are selectable; the cycle lists stay read-only,
+    //and the delete row stays inert until both interlocks are satisfied.
     func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
-        return indexPath.section == 2 ? indexPath : nil
+        if indexPath.section == 2 { return indexPath }
+        if indexPath.section == 3 { return canDelete ? indexPath : nil }
+        return nil
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        emailAllCyclesExport()
+        if indexPath.section == 2 {
+            emailAllCyclesExport()
+        } else if indexPath.section == 3 {
+            confirmDelete()
+        }
     }
 }

--- a/LocationApp/Utility View/DeleteOldCyclesViewController.swift
+++ b/LocationApp/Utility View/DeleteOldCyclesViewController.swift
@@ -7,12 +7,15 @@
 
 import Foundation
 import UIKit
+import MessageUI
+import AVFoundation
 
 //MARK:  Class
 
 //Super-user admin screen, reached from Tools behind the passcode gate.
-//Read-only preview of what a delete would affect: the latest cycles are
-//listed as protected, older cycles with their record counts.
+//Shows what a delete would affect (protected cycles, older cycles with
+//record counts) and the required first step: emailing a full all-cycles
+//export. Deleting stays locked until that export has actually been sent.
 class DeleteOldCyclesViewController: UIViewController {
 
     let locations = container.locations
@@ -28,6 +31,11 @@ class DeleteOldCyclesViewController: UIViewController {
     private var eligibleCycleCounts: [(cycle: String, count: Int)] = []
     private var eligibleTotal = 0
 
+    //Flips only when the mail sheet reports the export was sent — the
+    //delete step (next update) keys off this, so cancel/draft don't count.
+    private(set) var hasEmailedExport = false
+    private var exportedRecordCount = 0
+
     //MARK:  View lifecycle
 
     override func viewDidLoad() {
@@ -40,7 +48,7 @@ class DeleteOldCyclesViewController: UIViewController {
                                                             action: #selector(done))
 
         tableView.dataSource = self
-        tableView.allowsSelection = false
+        tableView.delegate = self
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)
         NSLayoutConstraint.activate([
@@ -90,48 +98,129 @@ class DeleteOldCyclesViewController: UIViewController {
               let year = Int(parts[2]) else { return Int.min }
         return year * 100 + month
     }
+
+    //MARK:  All-cycles export email
+
+    func emailAllCyclesExport() {
+        guard MFMailComposeViewController.canSendMail() else {
+            let alert = UIAlertController(title: "Mail Not Set Up",
+                                          message: "This device cannot send email. Set up a Mail account, then return here — the export must be emailed before anything can be deleted.",
+                                          preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+            present(alert, animated: true)
+            return
+        }
+
+        //Every cached record, all cycles — a superset of anything deletable.
+        let items = locations.filter(by: { _ in true })
+        let csv = CycleCSVExport.csvText(for: items)
+        exportedRecordCount = items.count
+
+        let protectedList = protectedCycles.joined(separator: ", ")
+        let mail = MFMailComposeViewController()
+        mail.mailComposeDelegate = self
+        mail.setSubject("Area Dosimeter Data - Full Export (All Cycles)")
+        mail.setMessageBody("Attached is a full export of all \(items.count) location records across all cycles, generated before deleting old cycles. Protected cycles: \(protectedList). Eligible for deletion: \(eligibleTotal) records in \(eligibleCycleCounts.count) older cycles.", isHTML: false)
+        mail.addAttachmentData(Data(csv.utf8), mimeType: "text/csv", fileName: "Dosi_Data_All_Cycles.csv")
+        present(mail, animated: true)
+
+        print("Delete Old Cycles: composing all-cycles export, \(items.count) records")
+    }
+}
+
+//MARK:  Mail compose delegate
+
+extension DeleteOldCyclesViewController: MFMailComposeViewControllerDelegate {
+
+    func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
+        controller.dismiss(animated: true)
+
+        switch result {
+        case .sent:
+            hasEmailedExport = true
+            //Same sent sound as the Tools email export.
+            let systemSoundID: SystemSoundID = 1001
+            AudioServicesPlaySystemSound(systemSoundID)
+            print("Delete Old Cycles: all-cycles export emailed (\(exportedRecordCount) records)")
+            tableView.reloadData()
+        case .failed:
+            print("Delete Old Cycles: export email failed: \(String(describing: error))")
+            let alert = UIAlertController(title: "Export Not Sent",
+                                          message: "The export email could not be sent. Deleting stays locked until an export is emailed successfully.",
+                                          preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+            present(alert, animated: true)
+        default:
+            //Cancelled or saved as draft — the export gate stays locked.
+            print("Delete Old Cycles: export email not sent (result \(result.rawValue))")
+        }
+    }
 }
 
 //MARK:  Table data source
 
 extension DeleteOldCyclesViewController: UITableViewDataSource {
 
+    //Sections: 0 protected cycles, 1 eligible cycles, 2 the export step.
     func numberOfSections(in tableView: UITableView) -> Int {
-        return 2
+        return 3
     }
 
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         if section == 0 {
             return "Protected — latest \(DeleteOldCyclesViewController.cyclesToKeep) cycles"
         }
-        return "Older cycles eligible for deletion"
+        if section == 1 {
+            return "Older cycles eligible for deletion"
+        }
+        return "Step 1 — Export all cycles"
     }
 
     func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         if section == 0 {
             return "Records in these cycles can never be deleted."
         }
-        if eligibleTotal == 0 {
-            return "No records older than the protected cycles were found."
+        if section == 1 {
+            if eligibleTotal == 0 {
+                return "No records older than the protected cycles were found."
+            }
+            return "\(eligibleTotal) records total. Deleting requires a fresh export of all cycles first — Step 1 below."
         }
-        return "\(eligibleTotal) records total. Deleting requires a fresh export of all cycles first — that step arrives in the next update."
+        if hasEmailedExport {
+            return "Export emailed — \(exportedRecordCount) records attached. The delete step arrives in the next update."
+        }
+        return "Emails a CSV of every record in every cycle. Required before anything can be deleted."
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if section == 0 {
             return protectedCycles.count
         }
-        return max(eligibleCycleCounts.count, 1)
+        if section == 1 {
+            return max(eligibleCycleCounts.count, 1)
+        }
+        return 1
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "cycleCell")
             ?? UITableViewCell(style: .value1, reuseIdentifier: "cycleCell")
+        cell.textLabel?.textColor = .label
+        cell.selectionStyle = .none
 
         if indexPath.section == 0 {
             cell.textLabel?.text = protectedCycles[indexPath.row]
             cell.detailTextLabel?.text = "Protected"
             cell.detailTextLabel?.textColor = .secondaryLabel
+            return cell
+        }
+
+        if indexPath.section == 2 {
+            cell.textLabel?.text = "Email All-Cycles Export"
+            cell.textLabel?.textColor = view.tintColor
+            cell.detailTextLabel?.text = hasEmailedExport ? "Sent ✓" : "Required"
+            cell.detailTextLabel?.textColor = hasEmailedExport ? .systemGreen : .secondaryLabel
+            cell.selectionStyle = .default
             return cell
         }
 
@@ -146,5 +235,20 @@ extension DeleteOldCyclesViewController: UITableViewDataSource {
         cell.detailTextLabel?.text = "\(entry.count) record\(entry.count == 1 ? "" : "s")"
         cell.detailTextLabel?.textColor = .secondaryLabel
         return cell
+    }
+}
+
+//MARK:  Table delegate
+
+extension DeleteOldCyclesViewController: UITableViewDelegate {
+
+    //Only the export row is actionable; the cycle lists stay read-only.
+    func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+        return indexPath.section == 2 ? indexPath : nil
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        emailAllCyclesExport()
     }
 }

--- a/LocationApp/Utility View/ToolsViewController.swift
+++ b/LocationApp/Utility View/ToolsViewController.swift
@@ -174,9 +174,9 @@ class ToolsViewController: UIViewController, MFMailComposeViewControllerDelegate
     
     //MARK:  Super-user delete
 
-    //Passcode gate for the delete-old-cycles admin screen. The integer
-    //passcode is checked against the cached Settings record, so it can be
-    //rotated from CloudKit without an app update ("04299" matches by design).
+    //Obfuscation-level gate (not real access control) for delete-old-cycles:
+    //the integer passcode is checked against the cached Settings record, so it
+    //can be rotated from CloudKit without an app update ("04299" matches).
     @IBAction func deleteOldCyclesTouchUp(_ sender: Any) {
         let alert = UIAlertController(title: "Super User Access",
                                       message: "Enter the passcode to manage old cycles.",

--- a/LocationApp/Utility View/ToolsViewController.swift
+++ b/LocationApp/Utility View/ToolsViewController.swift
@@ -43,6 +43,7 @@ class ToolsViewController: UIViewController, MFMailComposeViewControllerDelegate
     @IBOutlet weak var button3: UIButton!
     @IBOutlet weak var resetCacheButton: UIButton!
     @IBOutlet weak var dosimeters: UIButton!
+    @IBOutlet weak var deleteOldCyclesButton: UIButton!
     
     let borderColorUp = UIColor(red: 0.580723, green: 0.0667341, blue: 0, alpha: 1).cgColor
     let borderColorDown = UIColor(red: 0.580723, green: 0.0667341, blue: 0, alpha: 0.25).cgColor
@@ -65,6 +66,7 @@ class ToolsViewController: UIViewController, MFMailComposeViewControllerDelegate
         addBorderToButton(button: button3)
         addBorderToButton(button: resetCacheButton)
         addBorderToButton(button: dosimeters)
+        addBorderToButton(button: deleteOldCyclesButton)
         
         registerDevMode()
 
@@ -170,6 +172,51 @@ class ToolsViewController: UIViewController, MFMailComposeViewControllerDelegate
         present(alert, animated: true)
     }
     
+    //MARK:  Super-user delete
+
+    //Passcode gate for the delete-old-cycles admin screen. The integer
+    //passcode is checked against the cached Settings record, so it can be
+    //rotated from CloudKit without an app update ("04299" matches by design).
+    @IBAction func deleteOldCyclesTouchUp(_ sender: Any) {
+        let alert = UIAlertController(title: "Super User Access",
+                                      message: "Enter the passcode to manage old cycles.",
+                                      preferredStyle: .alert)
+        alert.addTextField { textField in
+            textField.keyboardType = .numberPad
+            textField.isSecureTextEntry = true
+            textField.placeholder = "Passcode"
+        }
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in
+            let entered = Int(alert.textFields?.first?.text ?? "")
+            container.settings.getSettings { settings in
+                DispatchQueue.main.async {
+                    if let entered = entered, entered == settings.superUserPasscodeValue {
+                        print("Super-user gate: passcode accepted, opening Delete Old Cycles")
+                        self.presentDeleteOldCycles()
+                    } else {
+                        print("Super-user gate: passcode rejected")
+                        self.presentWrongPasscode()
+                    }
+                }
+            }
+        }))
+        present(alert, animated: true)
+    }
+
+    func presentDeleteOldCycles() {
+        let controller = UINavigationController(rootViewController: DeleteOldCyclesViewController())
+        present(controller, animated: true)
+    }
+
+    func presentWrongPasscode() {
+        let alert = UIAlertController(title: "Incorrect Passcode",
+                                      message: "The passcode you entered is not correct.",
+                                      preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+        present(alert, animated: true)
+    }
+
     //MARK:  Send Email
     func sendEmail() {
         


### PR DESCRIPTION
## Summary

Adds a super-user "Delete Old Cycles" flow so field admins can purge records from cycles older than the protected window, directly from the device. The flow is built around two safety interlocks. A **forced full export** and a **type-DELETE confirmation** .So an irreversible CloudKit deletion can't happen by accident.

Reached from **Tools → Delete Old Cycles**, behind a numeric passcode.

## What's included (4 commits)

- **Data layer** (`40a7ce0`), `Cache.remove`, the pure latest-4-cycles protection decision, an eligible-records preview, and paginated CloudKit deletion (200/batch) with progress, offline-graceful stops, and audit logging.
- **Gated admin screen** (`1bed29e`), Tools button → Super User Access passcode gate (integer, rotatable from the CloudKit Settings record) → read-only preview of protected vs. eligible cycles with per-cycle counts.
- **Forced all-cycles export** (`d7d1ce4`), `CycleCSVExport` builds a complete audit CSV (Tools-compatible columns, every cached record, nil-safe blanks). The delete step stays locked until the export is actually **sent**.
- **Delete step** (`ca21c55`), type-DELETE confirmation (enabled only on an exact match), a progress alert driven by the per-batch callback, and a success / partial-stop result alert; 
- export recipient pre-filled to esh-DREP@slac.stanford.edu.

## Safety design

- The latest 4 cycles (2 years) are **hard-protected** and can never be deleted.
- A record with a nil `cycleDate` is **never** eligible.
- Eligibility is **recomputed in the data layer** at delete time, the UI gate is defense-in-depth, not the source of truth.
- Only **server-confirmed** deletions are removed from the cache, and the pending-changes queue is pruned so a queued upload can't resurrect a record.
- Deletes **stop gracefully** between batches when connectivity drops, reporting the partial count rather than failing or blocking the UI.
- The all-cycles CSV is a **strict superset** of anything deletable (it includes records the regular Tools export would skip), and free-text cells are quoted so commas/newlines can't shift columns.

## Testing

- **Unit suite 57/57 green** (iPhone 17, iOS 26.0.1), covers the protection decision matrix, `getLastCycles` contiguity, `Cache.remove` indexing + change pruning, the CSV header/row/sort/blank-cell/quoting output, the delete gate, the exact-match DELETE rule, and the export recipient.
- **Device-verified end to end** (screenshots below): wrong-passcode rejection, preview counts, recipient prefill, cancel-keeps-locked, send-unlocks, the type-DELETE guard, a live 68-record purge, and the post-delete re-lock.

## Notes

- Container is currently **Development** per `LocationApp.entitlements`.
- The passcode is an obfuscation-level gate (internal admin tool), not access control.

---
3. Screenshot Preview Markdown

## Screenshots — device walkthrough

<details>
<summary>Full flow (tap to expand)</summary>

### 1. Entry & passcode gate
**Tools screen — new "Delete Old Cycles" button**
<img width="660" height="1434" alt="Simulator Screenshot - iPhone 17 (QA-A) - 2026-06-15 at 19 28 36" src="https://github.com/user-attachments/assets/22e0aeb0-fc22-4e28-a2ef-ef5e4569bc19" />

**Super User Access — secure numeric passcode**
<img width="660" height="1434" alt="IMG_0475" src="https://github.com/user-attachments/assets/b129c4cf-339f-4522-b9bb-00e407f0fddc" />

**Wrong passcode is rejected**
<img width="660" height="1434" alt="IMG_0476" src="https://github.com/user-attachments/assets/fc2d8e98-7d89-4fe3-9bc6-f12dfdfee365" />

### 2. Preview (read-only)
**4 protected cycles + 68 records eligible across 5 older cycles**
<img width="660" height="1434" alt="IMG_0477" src="https://github.com/user-attachments/assets/69016b4f-b9cf-48df-a3b2-e23e22ba027a" />

**Step 2 is Locked before any export**
<img width="660" height="1434" alt="IMG_0478" src="https://github.com/user-attachments/assets/355a0eca-575c-4b56-b2ca-b1740602f1dc" />

### 3. Step 1 — forced export
**Recipient pre-filled to esh-DREP@slac.stanford.edu, CSV attached**
<img width="660" height="1434" alt="IMG_0479" src="https://github.com/user-attachments/assets/46e4c0cf-c4c7-4d6f-a6ca-65c5410a3d02" />

**Cc/Bcc can be added on top of the prefilled recipient**
<img width="660" height="1434" alt="IMG_0480" src="https://github.com/user-attachments/assets/93f984bd-056f-4c22-8a96-416c4cdd6be1" />

**After sending: Step 1 "Sent ✓", Step 2 unlocks (red)**
<img width="660" height="1434" alt="IMG_0481" src="https://github.com/user-attachments/assets/6d6d2848-682b-4043-9886-ae3c54447a29" />

### 4. Step 2 — type-DELETE confirmation
**Exact "DELETE" enables the destructive action**
<img width="660" height="1434" alt="IMG_0482" src="https://github.com/user-attachments/assets/b1403deb-9a9f-4ded-982e-fc0d2daedf84" />

**Partial "DELET" keeps it disabled**
<img width="660" height="1434" alt="IMG_0483" src="https://github.com/user-attachments/assets/d91a11a4-c4bd-420c-bbd3-38e2a90037dd" />

### 5. Delete & result
**Progress alert while deleting**
<img width="660" height="1434" alt="IMG_0484" src="https://github.com/user-attachments/assets/6717067f-eaaa-42e0-9362-6f412636e2f1" />

**Deletion Complete — 68 records deleted; preview refreshes, Step 2 re-locks**
<img width="660" height="1434" alt="IMG_0485" src="https://github.com/user-attachments/assets/03a597e9-a1d2-4e56-b14a-7d62f97ca328" />

**Fresh re-entry: no eligible cycles, gate reset**
<img width="660" height="1434" alt="IMG_0486" src="https://github.com/user-attachments/assets/a2ccb4e5-6360-4831-8d5e-b356d5aa9925" />

</details>