### PR TITLE
Add Refresh Count button and fix double email-sent sound

### DIFF
--- a/LocationApp/LocationApp/Base.lproj/Main.storyboard
+++ b/LocationApp/LocationApp/Base.lproj/Main.storyboard
@@ -368,6 +368,13 @@
                                 <color key="textColor" red="0.88717480959999995" green="0.88717480959999995" blue="0.88717480959999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RfC-rf-cnt">
+                                <rect key="frame" x="114" y="487" width="200" height="44"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="26"/>
+                                <state key="normal" title="Refresh Count">
+                                    <color key="titleColor" red="0.88717480959999995" green="0.88717480959999995" blue="0.88717480959999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                            </button>
                             <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Version 1.3" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zuC-3j-mde">
                                 <rect key="frame" x="179" y="860" width="70.333333333333314" height="17"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -378,6 +385,9 @@
                         <viewLayoutGuide key="safeArea" id="QGn-nO-09E"/>
                         <color key="backgroundColor" red="0.58075547220000001" green="0.065336786209999997" blue="0.00062786263879999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
+                            <constraint firstItem="RfC-rf-cnt" firstAttribute="leading" secondItem="QGn-nO-09E" secondAttribute="centerX" constant="-100" id="RfC-ld-001"/>
+                            <constraint firstItem="RfC-rf-cnt" firstAttribute="trailing" secondItem="QGn-nO-09E" secondAttribute="centerX" constant="100" id="RfC-tr-001"/>
+                            <constraint firstItem="RfC-rf-cnt" firstAttribute="top" secondItem="Yg7-fX-lCZ" secondAttribute="bottom" constant="24" id="RfC-tp-001"/>
                             <constraint firstItem="C5U-sR-g2Z" firstAttribute="top" secondItem="HdU-d6-efg" secondAttribute="bottom" constant="38" id="3u2-P5-4h2"/>
                             <constraint firstItem="wOM-u4-FVE" firstAttribute="leading" secondItem="QGn-nO-09E" secondAttribute="centerX" constant="-95" id="E3i-Am-1aa"/>
                             <constraint firstItem="dgk-90-ebF" firstAttribute="top" secondItem="wOM-u4-FVE" secondAttribute="bottom" constant="30" id="Gyv-UI-T5R"/>
@@ -410,6 +420,7 @@
                         <outlet property="progressView" destination="C5U-sR-g2Z" id="TAu-KM-Q6h"/>
                         <outlet property="scanButton" destination="wOM-u4-FVE" id="MLU-kG-PiW"/>
                         <outlet property="statusLabel" destination="Yg7-fX-lCZ" id="IB8-3Q-Jxf"/>
+                        <outlet property="refreshButton" destination="RfC-rf-cnt" id="RfC-ou-001"/>
                         <outlet property="versionLabel" destination="zuC-3j-mde" id="Qi6-dP-Vjw"/>
                         <segue destination="M89-R5-CVf" kind="show" identifier="segueToTools" id="zta-o7-k1W"/>
                     </connections>

--- a/LocationApp/LocationApp/StartupViewController.swift
+++ b/LocationApp/LocationApp/StartupViewController.swift
@@ -31,6 +31,7 @@ class StartupViewController: UIViewController, MFMailComposeViewControllerDelega
     @IBOutlet weak var activityIndicator: UIActivityIndicatorView!
     @IBOutlet weak var progressView: UIProgressView!
     @IBOutlet weak var statusLabel: UILabel!
+    @IBOutlet weak var refreshButton: UIButton!
     
     @IBOutlet weak var versionLabel: UILabel!
     @IBOutlet weak var Tools: UIImageView!
@@ -67,10 +68,11 @@ class StartupViewController: UIViewController, MFMailComposeViewControllerDelega
         Tools.isUserInteractionEnabled = true
         Tools.addGestureRecognizer(toolsTap)
         
-        //tap to refresh status
-        let statusTap = UITapGestureRecognizer(target: self, action: #selector(setProgress))
-        statusLabel.isUserInteractionEnabled = true
-        statusLabel.addGestureRecognizer(statusTap)
+        //refresh count button (replaces the hidden tap-to-refresh on the status label)
+        refreshButton.layer.borderWidth = 1.5
+        refreshButton.layer.borderColor = borderColorUp
+        refreshButton.layer.cornerRadius = 22
+        refreshButton.addTarget(self, action: #selector(setProgress), for: .touchUpInside)
         
         // Do any additional setup after loading the view, typically from a nib.
         // Detect Wifi:

--- a/LocationApp/LocationAppTests/LocationAppTests.swift
+++ b/LocationApp/LocationAppTests/LocationAppTests.swift
@@ -797,4 +797,39 @@ class LocationAppTests: XCTestCase {
     func test_exportRecipient_isTheRecordsManagementGroup() {
         XCTAssertEqual(DeleteOldCyclesViewController.exportRecipient, "esh-DREP@slac.stanford.edu")
     }
+
+    // MARK: - Refresh Count button wiring
+
+    // Wired in the storyboard + viewDidLoad with no pure logic, so these load the
+    // startup scene to check the button's outlet, title, and action and that the old
+    // hidden tap is gone. Loading runs viewDidLoad; we stop the notifier right after.
+
+    private func loadStartupViewController() throws -> StartupViewController {
+        let storyboard = UIStoryboard(name: "Main", bundle: Bundle(for: StartupViewController.self))
+        let controller = storyboard.instantiateViewController(withIdentifier: "Main")
+        let startup = try XCTUnwrap(controller as? StartupViewController,
+                                    "Main storyboard identifier \"Main\" should resolve to StartupViewController")
+        startup.loadViewIfNeeded()
+        startup.reachability.stopNotifier()
+        return startup
+    }
+
+    func test_refreshCountButton_isConnectedAndCallsSetProgress() throws {
+        let startup = try loadStartupViewController()
+
+        let button = try XCTUnwrap(startup.refreshButton,
+                                   "refreshButton outlet must be connected in Main.storyboard")
+        XCTAssertEqual(button.title(for: .normal), "Refresh Count")
+
+        let actions = button.actions(forTarget: startup, forControlEvent: .touchUpInside) ?? []
+        XCTAssertTrue(actions.contains("setProgress"),
+                      "Refresh Count button must trigger setProgress on touchUpInside")
+    }
+
+    func test_statusLabel_noLongerHasHiddenTapToRefresh() throws {
+        let startup = try loadStartupViewController()
+
+        XCTAssertTrue((startup.statusLabel.gestureRecognizers ?? []).isEmpty,
+                      "the hidden tap-to-refresh gesture should be removed from the status label")
+    }
 }

--- a/LocationApp/Utility View/DeleteOldCyclesViewController.swift
+++ b/LocationApp/Utility View/DeleteOldCyclesViewController.swift
@@ -8,7 +8,6 @@
 import Foundation
 import UIKit
 import MessageUI
-import AVFoundation
 
 //MARK:  Class
 
@@ -270,9 +269,7 @@ extension DeleteOldCyclesViewController: MFMailComposeViewControllerDelegate {
         switch result {
         case .sent:
             hasEmailedExport = true
-            //Same sent sound as the Tools email export.
-            let systemSoundID: SystemSoundID = 1001
-            AudioServicesPlaySystemSound(systemSoundID)
+            //MFMailComposeViewController already plays the sent sound itself; don't double it.
             print("Delete Old Cycles: all-cycles export emailed (\(exportedRecordCount) records)")
             tableView.reloadData()
         case .failed:

--- a/LocationApp/Utility View/ToolsViewController.swift
+++ b/LocationApp/Utility View/ToolsViewController.swift
@@ -9,7 +9,6 @@
 import Foundation
 import UIKit
 import MessageUI
-import AVFoundation
 //MARK:  Class
 class ToolsViewController: UIViewController, MFMailComposeViewControllerDelegate {
     
@@ -244,10 +243,7 @@ class ToolsViewController: UIViewController, MFMailComposeViewControllerDelegate
     
     
     func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
-        
-        //Play email sent sound
-        let systemSoundID: SystemSoundID =  1001
-        AudioServicesPlaySystemSound(systemSoundID)
+        //MFMailComposeViewController already plays the sent sound itself; don't double it.
         controller.dismiss(animated: true)
     } //end func mailComposeController
     


### PR DESCRIPTION
## Summary

Two changes to the startup and email flows:

1. **"Refresh Count" button (R4)** — replaces the hidden tap-to-refresh on the home-screen status label with a visible button. Same refresh behavior as before, now discoverable.
2. **Double email "woosh" fix** — removed the app's explicit mail-sent sound; `MFMailComposeViewController` already plays it, so it was playing twice. Applies to both the Tools export and the Delete Old Cycles export.

## For review (@ryanfordSLAC ): does this match what you pictured?

Flagging the button for your sign-off before merge.

R4: *"Change the progress bar tap to refresh to a visible button with the text 'Refresh Count'. Same function as tap to refresh."*

- ✅ Visible button labeled **Refresh Count**, sized/styled to match Scan Barcode / Map View / List View
- ✅ Tapping it runs the same `setProgress()` refresh the old hidden tap used (incremental sync → recomputed count + progress bar)
- ✅ Loading indicator — the existing center spinner animates during the refresh

## Screenshot

![Refresh Count button on the startup screen](https://github.com/user-attachments/assets/c7ea2fd9-ceef-4592-ade1-002ddd31fd0f)

## Testing

- Unit suite: **59/59 passing**, including two new storyboard-wiring tests for the button (outlet connected, title `Refresh Count`, `setProgress` action wired, and the old hidden tap removed).
- On-device: tapped Refresh Count to CloudKit query ran, pulled new records, count recomputed; single "woosh" confirmed on email send.