### PR TITLE
Fix email-data export crash on records with nil system dates

### DIFF
--- a/LocationApp/LocationAppTests/LocationAppTests.swift
+++ b/LocationApp/LocationAppTests/LocationAppTests.swift
@@ -651,6 +651,51 @@ class LocationAppTests: XCTestCase {
                        "Header + one row + End of File + the trailing newline's empty component")
     }
 
+    // MARK: - Tools "email data" export nil-date crash
+
+    // recordFetchedBlock builds each CSV line for the Tools "email data" export. It
+    // used to force-unwrap the CKRecord system dates, which are nil for unsynced or
+    // orphan records — one such record crashed the whole export. These pin nil-safety.
+
+    func test_recordFetchedBlock_withNilSystemDates_doesNotCrashAndBlanksDateCells() throws {
+        let tools = ToolsViewController()
+        let record = try makeItem(recordName: "ghost-record")
+        XCTAssertNil(record.creationDate, "Precondition: the record must lack a system creation date")
+        XCTAssertNil(record.modificationDate, "Precondition: the record must lack a system modification date")
+
+        tools.recordFetchedBlock(record: record) // must not crash on the missing dates
+
+        // The row is produced (no crash), and the two system-date columns it used
+        // to force-unwrap (9 = deployed, 10 = collected) render as blank cells.
+        let cells = tools.csvText.components(separatedBy: ",")
+        XCTAssertEqual(cells.count, 17, "The export row must keep all 17 columns even with missing dates")
+        XCTAssertEqual(cells[0], "Q")
+        XCTAssertEqual(cells[9], "", "A nil system deploy date must be a blank cell, not a crash")
+        XCTAssertEqual(cells[10], "", "A nil system collected date must be a blank cell, not a crash")
+        XCTAssertEqual(cells[14], "ghost-record", "The record ID column must still render")
+    }
+
+    func test_recordFetchedBlock_withSystemDates_rendersFormattedDates() throws {
+        let deployed = try XCTUnwrap(noonLocal(year: 2026, month: 6, day: 5))
+        let collected = try XCTUnwrap(noonLocal(year: 2026, month: 6, day: 10))
+        let json = """
+        { "QRCode": "BLG 006-015", "latitude": "37.4", "longitude": "-122.2", \
+        "locdescription": "north gate", "active": 1, \
+        "creationDate": \(deployed.timeIntervalSinceReferenceDate), \
+        "modificationDate": \(collected.timeIntervalSinceReferenceDate), \
+        "recordName": "rec-1", "hasPhoto": false }
+        """
+        let record = try JSONDecoder().decode(LocationRecordCacheItem.self, from: Data(json.utf8))
+
+        let tools = ToolsViewController()
+        tools.recordFetchedBlock(record: record)
+
+        // Columns 9 and 10 are the system deploy/collected dates (MM/dd/yyyy).
+        let cells = tools.csvText.components(separatedBy: ",")
+        XCTAssertEqual(cells[9], "06/05/2026", "System deploy date must still render when present")
+        XCTAssertEqual(cells[10], "06/10/2026", "System collected date must still render when present")
+    }
+
     /// Noon local time avoids DST-edge surprises when the exporter formats
     /// the date back in the current calendar.
     private func noonLocal(year: Int, month: Int, day: Int) -> Date? {

--- a/LocationApp/Utility View/ToolsViewController.swift
+++ b/LocationApp/Utility View/ToolsViewController.swift
@@ -332,13 +332,17 @@ extension ToolsViewController {
         
         //system dates - createdDate and modifiedDate Ver 1.2
         
-        //block 3: these fields always have a value and are called differently than my date fields
-        let date = Date(timeInterval: 0, since: record.creationDate!)
-        //let date = Date(timeInterval: 0, since: record["createdDate"] as! Date) //Ver 1.2
-        let formattedDate = dateFormatter.string(from: date)
-        let dateModified = Date(timeInterval: 0, since: record.modificationDate!)
-        //let dateModified = Date(timeInterval: 0, since: record["modifiedDate"] as! Date)
-        let formattedDateModified = dateFormatter.string(from: dateModified)
+        //block 3: system dates - nil for records not yet synced (created offline) or
+        //older orphan records. Render blank instead of force-unwrapping (which crashed
+        //the export); same blank-cell behavior as CycleCSVExport.
+        var formattedDate = ""
+        if let creationDate = record.creationDate {
+            formattedDate = dateFormatter.string(from: Date(timeInterval: 0, since: creationDate))
+        }
+        var formattedDateModified = ""
+        if let modificationDate = record.modificationDate {
+            formattedDateModified = dateFormatter.string(from: Date(timeInterval: 0, since: modificationDate))
+        }
         
         //block 4: may not have a value when initially set up and tested
         //but will eventually always have a value
@@ -358,7 +362,7 @@ extension ToolsViewController {
             myDateModified = Date(timeInterval: -1E15, since: Date())
         }
         let myformattedDateModified = dateFormatter.string(from: myDateModified!)
-        let recordID = record.recordName!
+        let recordID = record.recordName ?? ""
         let modifiedBy = record.modifiedBy ?? ""
         let group = record.reportGroup ?? ""
         


### PR DESCRIPTION
## Summary

The Tools **"email data"** export crashed with *"Unexpectedly found nil while unwrapping an Optional value"* at `ToolsViewController.swift:336`. The CSV row builder (`recordFetchedBlock`) force-unwrapped each record's CloudKit **system** dates, `record.creationDate!` and `record.modificationDate!`. Those system dates are `nil` for any record that hasn't completed a full CloudKit round-trip (created or queued while offline, still pending upload) and for older orphan records missing their dates. The first such record in the export set killed the whole loop, so the spinner ran forever and the email was never produced, repeatable across cycles.

This blocks the export-before-delete safety step, since cycles can't be deleted until their data is emailed.

## Fix

- `recordFetchedBlock` now renders a **blank cell** for a missing system date instead of force-unwrapping it — the same blank-on-nil behavior already used by `CycleCSVExport.format`, so the two export paths stay consistent. Chose the explicit blank over block 4's `-1E15` sentinel so output doesn't depend on the date formatter's extreme-date edge case.
- Hardened the adjacent `record.recordName!` force-unwrap on the same row (`?? ""`).
- Block 4 (the app's custom date fields) was already nil-guarded and is untouched.

## Tests

Two regression tests drive the real `recordFetchedBlock`:

- `test_recordFetchedBlock_withNilSystemDates_doesNotCrashAndBlanksDateCells`, reproduces the exact crash condition; asserts no crash, all 17 columns intact, the two system-date columns blank, and the record ID still rendered.
- `test_recordFetchedBlock_withSystemDates_rendersFormattedDates`, confirms dated records still render `MM/dd/yyyy` (no regression).

Full suite **61/61 passing** (was 59), iPhone 17 / iOS 26.0.1 simulator.