### PR TITLE
Gate Reset Cache and Edit Record save behind the super-user passcode

### DIFF
--- a/LocationApp/LocationApp.xcodeproj/project.pbxproj
+++ b/LocationApp/LocationApp.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		845F2E5F221C62E200A48C1A /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845F2E5E221C62E200A48C1A /* Reachability.swift */; };
 		846606C121AA3CA00049814C /* ReadWriteText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846606C021AA3CA00049814C /* ReadWriteText.swift */; };
 		DA20260612000000000000B2 /* CycleCSVExport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA20260612000000000000B1 /* CycleCSVExport.swift */; };
+		DA20260617000000000000C2 /* SuperUserGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA20260617000000000000C1 /* SuperUserGate.swift */; };
 		846606C321AA5C380049814C /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846606C221AA5C380049814C /* MapViewController.swift */; };
 		84712D582597C874006F31E4 /* Briefcase.csv in Resources */ = {isa = PBXBuildFile; fileRef = 84712D572597C874006F31E4 /* Briefcase.csv */; };
 		84712D622597C9FA006F31E4 /* Version 1.2 Briefcase Flowchart.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 84712D612597C9FA006F31E4 /* Version 1.2 Briefcase Flowchart.pdf */; };
@@ -120,6 +121,7 @@
 		845F2E5E221C62E200A48C1A /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
 		846606C021AA3CA00049814C /* ReadWriteText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadWriteText.swift; sourceTree = "<group>"; };
 		DA20260612000000000000B1 /* CycleCSVExport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CycleCSVExport.swift; sourceTree = "<group>"; };
+		DA20260617000000000000C1 /* SuperUserGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperUserGate.swift; sourceTree = "<group>"; };
 		846606C221AA5C380049814C /* MapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewController.swift; sourceTree = "<group>"; };
 		846D6B4F2170160E008E003D /* LocationApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = LocationApp.entitlements; sourceTree = "<group>"; };
 		84712D572597C874006F31E4 /* Briefcase.csv */ = {isa = PBXFileReference; lastKnownFileType = text; path = Briefcase.csv; sourceTree = "<group>"; };
@@ -323,6 +325,7 @@
 			isa = PBXGroup;
 			children = (
 				5CF01FDD22D92F19004604BC /* ToolsViewController.swift */,
+				DA20260617000000000000C1 /* SuperUserGate.swift */,
 				DA20260611000000000000A1 /* DeleteOldCyclesViewController.swift */,
 				84571FE4258FE29C009AC936 /* BriefCase.swift */,
 				5CFF888A22CAA5B700611F60 /* ActiveLocations.swift */,
@@ -538,6 +541,7 @@
 				449A7E9D271341B2005AF1F7 /* LocationRecordCacheItem.swift in Sources */,
 				846606C121AA3CA00049814C /* ReadWriteText.swift in Sources */,
 				DA20260612000000000000B2 /* CycleCSVExport.swift in Sources */,
+				DA20260617000000000000C2 /* SuperUserGate.swift in Sources */,
 				8487FE3021A8F9C700CC62E8 /* StartupViewController.swift in Sources */,
 				5E4D12742A2776E9002E4D91 /* Slac.swift in Sources */,
 				5A5EFD742A306ED500547EB8 /* SettingsService.swift in Sources */,

--- a/LocationApp/LocationAppTests/LocationAppTests.swift
+++ b/LocationApp/LocationAppTests/LocationAppTests.swift
@@ -843,6 +843,45 @@ class LocationAppTests: XCTestCase {
         XCTAssertEqual(DeleteOldCyclesViewController.exportRecipient, "esh-DREP@slac.stanford.edu")
     }
 
+    // MARK: - Super-user passcode gate (shared by Reset Cache + Delete Old Cycles + Edit Record)
+
+    // passcodeAccepted is the pure decision the shared gate consults. It must
+    // accept only the exact configured passcode and reject empty, non-numeric,
+    // or wrong input — the same check guards Reset Cache and Edit Record saves.
+    func test_passcodeAccepted_trueOnlyForExactConfiguredValue() {
+        XCTAssertTrue(SuperUserGate.passcodeAccepted(entered: "4299", configured: 4299))
+        XCTAssertFalse(SuperUserGate.passcodeAccepted(entered: "4298", configured: 4299),
+                       "A wrong passcode must not open the gate")
+    }
+
+    func test_passcodeAccepted_rejectsEmptyAndNonNumericInput() {
+        for rejected in [nil, "", " ", "abc", "42x", "4299 "] {
+            XCTAssertFalse(SuperUserGate.passcodeAccepted(entered: rejected, configured: 4299),
+                           "\(String(describing: rejected)) must not open the gate")
+        }
+    }
+
+    func test_passcodeAccepted_honorsRotatedPasscode() {
+        // The configured value comes from settings.superUserPasscodeValue, which
+        // CloudKit can rotate; the gate must follow it, not a hardcoded default.
+        XCTAssertTrue(SuperUserGate.passcodeAccepted(entered: "8121", configured: 8121))
+        XCTAssertFalse(SuperUserGate.passcodeAccepted(entered: "4299", configured: 8121),
+                       "The old default must stop working once the passcode is rotated")
+    }
+
+    // Once-per-session unlock: the flag must be app-wide (a static), so it
+    // survives LocationDetails being re-instantiated per navigation.
+    func test_editRecordSavesUnlocked_isAppWideSessionFlag() {
+        let original = SuperUserGate.editRecordSavesUnlocked
+        defer { SuperUserGate.editRecordSavesUnlocked = original }
+
+        SuperUserGate.editRecordSavesUnlocked = false
+        XCTAssertFalse(SuperUserGate.editRecordSavesUnlocked)
+        SuperUserGate.editRecordSavesUnlocked = true
+        XCTAssertTrue(SuperUserGate.editRecordSavesUnlocked,
+                      "Once unlocked, Edit Record saves stay unlocked for the rest of the session")
+    }
+
     // MARK: - Refresh Count button wiring
 
     // Wired in the storyboard + viewDidLoad with no pure logic, so these load the

--- a/LocationApp/Utility View/LocationDetails.swift
+++ b/LocationApp/Utility View/LocationDetails.swift
@@ -410,13 +410,25 @@ extension LocationDetails: UITextFieldDelegate {
     
     @IBAction func popupSave(_ sender: Any) {
         if(pDosimeter.text != nil && self.validateDosimeterField(value: pDosimeter.text!)){
-            view.endEditing(true)
-            savePopupRecord()
-            self.dismiss(animated: true)
+            //Gate the save behind the super-user passcode, once per app session.
+            if SuperUserGate.editRecordSavesUnlocked {
+                commitPopupSave()
+            } else {
+                requireSuperUserPasscode(message: "Enter the passcode to save changes.") {
+                    SuperUserGate.editRecordSavesUnlocked = true
+                    self.commitPopupSave()
+                }
+            }
         } else {
             self.showDosimeterValidationWarning()
         }
-        
+
+    }
+
+    func commitPopupSave() {
+        view.endEditing(true)
+        savePopupRecord()
+        self.dismiss(animated: true)
     }
     
     func savePopupRecord() {

--- a/LocationApp/Utility View/SuperUserGate.swift
+++ b/LocationApp/Utility View/SuperUserGate.swift
@@ -1,0 +1,66 @@
+//
+//  SuperUserGate.swift
+//  LocationApp
+//
+//  Created by Daniel Spady on 6/17/26.
+//
+
+import UIKit
+
+//Obfuscation-level super-user gate (not real access control) shared across
+//screens. The passcode is checked against the cached Settings record, so it
+//can be rotated from CloudKit without an app update.
+enum SuperUserGate {
+
+    //Pure decision: entered text must parse to an integer equal to the
+    //configured passcode; empty or non-numeric input is rejected.
+    static func passcodeAccepted(entered: String?, configured: Int) -> Bool {
+        guard let value = Int(entered ?? "") else { return false }
+        return value == configured
+    }
+
+    //Once-per-session unlock for saving Edit Record edits. A static so it is
+    //app-wide and survives LocationDetails being re-instantiated per navigation;
+    //it resets to false on each app launch, so the first save of a session prompts.
+    static var editRecordSavesUnlocked = false
+}
+
+extension UIViewController {
+
+    //Prompt for the super-user passcode, then run onSuccess only if it matches
+    //the configured value. Shared by Reset Cache, Delete Old Cycles, Edit Record.
+    func requireSuperUserPasscode(message: String, onSuccess: @escaping () -> Void) {
+        let alert = UIAlertController(title: "Super User Access",
+                                      message: message,
+                                      preferredStyle: .alert)
+        alert.addTextField { textField in
+            textField.keyboardType = .numberPad
+            textField.isSecureTextEntry = true
+            textField.placeholder = "Passcode"
+        }
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in
+            let entered = alert.textFields?.first?.text
+            container.settings.getSettings { settings in
+                DispatchQueue.main.async {
+                    if SuperUserGate.passcodeAccepted(entered: entered, configured: settings.superUserPasscodeValue) {
+                        print("Super-user gate: passcode accepted")
+                        onSuccess()
+                    } else {
+                        print("Super-user gate: passcode rejected")
+                        self.presentWrongPasscode()
+                    }
+                }
+            }
+        }))
+        present(alert, animated: true)
+    }
+
+    func presentWrongPasscode() {
+        let alert = UIAlertController(title: "Incorrect Passcode",
+                                      message: "The passcode you entered is not correct.",
+                                      preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+        present(alert, animated: true)
+    }
+}

--- a/LocationApp/Utility View/ToolsViewController.swift
+++ b/LocationApp/Utility View/ToolsViewController.swift
@@ -150,6 +150,15 @@ class ToolsViewController: UIViewController, MFMailComposeViewControllerDelegate
     }
     
     @IBAction func resetCacheTouchUp(_ sender: Any) {
+        requireSuperUserPasscode(message: "Enter the passcode to reset the cache.") {
+            self.confirmResetCache()
+        }
+    }
+
+    //The Reset Cache? confirmation, shown only after the passcode is accepted.
+    //locations.reset syncs any pending edits before reloading, so the warning
+    //line and that safeguard are preserved.
+    func confirmResetCache() {
         let pending = locations.pendingChangeCount
         let pendingLine = pending > 0
             ? "\n\nYou have \(pending) unsynced edit\(pending == 1 ? "" : "s") that will sync first."
@@ -170,50 +179,19 @@ class ToolsViewController: UIViewController, MFMailComposeViewControllerDelegate
         }))
         present(alert, animated: true)
     }
-    
+
     //MARK:  Super-user delete
 
-    //Obfuscation-level gate (not real access control) for delete-old-cycles:
-    //the integer passcode is checked against the cached Settings record, so it
-    //can be rotated from CloudKit without an app update ("04299" matches).
+    //The shared gate (requireSuperUserPasscode) lives in SuperUserGate.swift.
     @IBAction func deleteOldCyclesTouchUp(_ sender: Any) {
-        let alert = UIAlertController(title: "Super User Access",
-                                      message: "Enter the passcode to manage old cycles.",
-                                      preferredStyle: .alert)
-        alert.addTextField { textField in
-            textField.keyboardType = .numberPad
-            textField.isSecureTextEntry = true
-            textField.placeholder = "Passcode"
+        requireSuperUserPasscode(message: "Enter the passcode to manage old cycles.") {
+            self.presentDeleteOldCycles()
         }
-        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
-        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in
-            let entered = Int(alert.textFields?.first?.text ?? "")
-            container.settings.getSettings { settings in
-                DispatchQueue.main.async {
-                    if let entered = entered, entered == settings.superUserPasscodeValue {
-                        print("Super-user gate: passcode accepted, opening Delete Old Cycles")
-                        self.presentDeleteOldCycles()
-                    } else {
-                        print("Super-user gate: passcode rejected")
-                        self.presentWrongPasscode()
-                    }
-                }
-            }
-        }))
-        present(alert, animated: true)
     }
 
     func presentDeleteOldCycles() {
         let controller = UINavigationController(rootViewController: DeleteOldCyclesViewController())
         present(controller, animated: true)
-    }
-
-    func presentWrongPasscode() {
-        let alert = UIAlertController(title: "Incorrect Passcode",
-                                      message: "The passcode you entered is not correct.",
-                                      preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-        present(alert, animated: true)
     }
 
     //MARK:  Send Email


### PR DESCRIPTION
## Summary

Adds the super-user passcode gate to two more destructive/record-modifying actions, using the same passcode that already protects Delete Old Cycles (checked against the CloudKit-rotatable Settings value, default 4299).

- **Reset Cache** now requires the passcode before its "Reset Cache?" confirmation appears. This is the action technicians were overusing; the gate keeps a full reload to the supervisor while leaving the safe Refresh Count button open to everyone.
- **Edit Record save** now requires the passcode. Per the agreed design, **only the Save action is gated** — viewing the Edit Record popup stays open to all — and the unlock is **once per session** (the first correct passcode unlocks saves for the rest of the app session).

## Implementation

- Extracted the gate into a new shared `Utility View/SuperUserGate.swift`:
- `SuperUserGate.passcodeAccepted(entered:configured:)` — the pure decision
- `UIViewController.requireSuperUserPasscode(message:onSuccess:)` + `presentWrongPasscode()` — the shared prompt, usable from any screen
- `SuperUserGate.editRecordSavesUnlocked` — the once-per-session unlock, a static so it's app-wide and survives `LocationDetails` being re-instantiated per navigation
- `ToolsViewController.resetCacheTouchUp` runs the gate before the extracted `confirmResetCache()`; the pending-edits-sync-first safeguard is preserved.
- `LocationDetails.popupSave` gates after dosimeter validation, committing via the extracted `commitPopupSave()`.
- Delete Old Cycles was refactored onto the same shared gate with **no behavior change**.

## Tests

- `passcodeAccepted`: exact-match acceptance, rejection of empty/non-numeric/wrong input, and honoring a rotated passcode.
- `editRecordSavesUnlocked`: the unlock flag is app-wide / session-persistent.

Full suite **65/65 passing** (iPhone 17, iOS 26.0.1). Device-verified: the passcode prompt appears for Reset Cache, Delete Old Cycles, and Edit Record save, and the unlock persists for the session.