### PR TITLE
Relabel Mismatch as RGD in UI and CSV export

### DIFF
--- a/LocationApp/LocationApp/Base.lproj/Main.storyboard
+++ b/LocationApp/LocationApp/Base.lproj/Main.storyboard
@@ -849,7 +849,7 @@
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Mismatch: " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="51I-IM-tmC">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="RGD: " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="51I-IM-tmC">
                                         <rect key="frame" x="29" y="356" width="76" height="17"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                         <nil key="textColor"/>

--- a/LocationApp/LocationAppTests/LocationAppTests.swift
+++ b/LocationApp/LocationAppTests/LocationAppTests.swift
@@ -576,8 +576,21 @@ class LocationAppTests: XCTestCase {
 
     func test_csvHeader_matchesTheToolsExportColumns() {
         XCTAssertEqual(CycleCSVExport.header,
-                       "LocationID (QRCode),Latitude,Longitude,Description,Moderator (0/1),Active (0/1),Dosimeter,Collected Flag (0/1),Wear Period,System_Date Deployed,System_Date Collected,Mismatch (0/1), my_Date Deployed, my_Date Collected, recordID, ModifiedBy, Report Group\n",
+                       "LocationID (QRCode),Latitude,Longitude,Description,Moderator (0/1),Active (0/1),Dosimeter,Collected Flag (0/1),Wear Period,System_Date Deployed,System_Date Collected,RGD (0/1), my_Date Deployed, my_Date Collected, recordID, ModifiedBy, Report Group\n",
                        "Header must stay column-compatible with the Tools email export")
+    }
+
+    // Pins the Mismatch -> RGD relabel. Display-only: the exported column header
+    // reads "RGD", but the backend CKRecord key stays "mismatch" (see the to()
+    // round-trip test, which asserts server["mismatch"]).
+    func test_csvHeader_usesRGDLabel() {
+        XCTAssertTrue(CycleCSVExport.header.contains("RGD (0/1)"),
+                      "Exported header should expose the column as \"RGD (0/1)\"")
+    }
+
+    func test_csvHeader_dropsOldMismatchLabel() {
+        XCTAssertFalse(CycleCSVExport.header.contains("Mismatch"),
+                       "The old \"Mismatch\" label must not appear in the exported header")
     }
 
     func test_row_rendersEveryFieldInColumnOrder() throws {

--- a/LocationApp/Scanner/ScannerViewController.swift
+++ b/LocationApp/Scanner/ScannerViewController.swift
@@ -768,7 +768,7 @@ extension ScannerViewController {  //alerts
             self.alert11a()
         }
         
-        let mismatch = UIAlertAction(title: "Mismatch", style: .default) { (_) in
+        let mismatch = UIAlertAction(title: "RGD", style: .default) { (_) in
             self.alert3a()
         }
         
@@ -794,7 +794,7 @@ extension ScannerViewController {  //alerts
             self.alert11()
         }
         
-        let mismatch = UIAlertAction(title: "Mismatch", style: .default) { (_) in
+        let mismatch = UIAlertAction(title: "RGD", style: .default) { (_) in
             self.alert3i() //reopen alert
         }
         

--- a/LocationApp/Text File/CycleCSVExport.swift
+++ b/LocationApp/Text File/CycleCSVExport.swift
@@ -15,7 +15,7 @@ import Foundation
 //is a complete audit copy of anything a delete could touch.
 struct CycleCSVExport {
 
-    static let header = "LocationID (QRCode),Latitude,Longitude,Description,Moderator (0/1),Active (0/1),Dosimeter,Collected Flag (0/1),Wear Period,System_Date Deployed,System_Date Collected,Mismatch (0/1), my_Date Deployed, my_Date Collected, recordID, ModifiedBy, Report Group\n"
+    static let header = "LocationID (QRCode),Latitude,Longitude,Description,Moderator (0/1),Active (0/1),Dosimeter,Collected Flag (0/1),Wear Period,System_Date Deployed,System_Date Collected,RGD (0/1), my_Date Deployed, my_Date Collected, recordID, ModifiedBy, Report Group\n"
 
     //Whole-file build: header, one row per record (QRCode ascending, newest
     //deploy first within a QRCode — same ordering as the Tools export), then

--- a/LocationApp/Utility View/ToolsViewController.swift
+++ b/LocationApp/Utility View/ToolsViewController.swift
@@ -260,7 +260,7 @@ extension ToolsViewController {
         //set first line of text file
         //should separate text file from query
         dispatchGroup.enter()
-        self.csvText = "LocationID (QRCode),Latitude,Longitude,Description,Moderator (0/1),Active (0/1),Dosimeter,Collected Flag (0/1),Wear Period,System_Date Deployed,System_Date Collected,Mismatch (0/1), my_Date Deployed, my_Date Collected, recordID, ModifiedBy, Report Group\n"
+        self.csvText = "LocationID (QRCode),Latitude,Longitude,Description,Moderator (0/1),Active (0/1),Dosimeter,Collected Flag (0/1),Wear Period,System_Date Deployed,System_Date Collected,RGD (0/1), my_Date Deployed, my_Date Collected, recordID, ModifiedBy, Report Group\n"
         
         var filter: ((LocationRecordCacheItem) -> Bool) = { l in l.createdDate != nil }
         if cycles > 0 {


### PR DESCRIPTION
## Summary

Renames the user-facing **"Mismatch"** control and CSV column to **"RGD"** (Radiation Generating Device). This is a display-only relabel — the underlying CloudKit field is untouched.

## Description

The Mismatch toggle was an early-build feature that turned out to have little practical use. Repurposing the existing control/column as "RGD" reuses the plumbing already in place rather than adding a new field, with no schema or data migration.

## Changes

- **Scanner alerts** (`ScannerViewController` `alert3a`/`alert3i`) — exchange/collect button title `"Mismatch"` to `"RGD"`
- **Location detail** (`Main.storyboard`) — switch label `"Mismatch: "` to `"RGD: "`
- **CSV exports** — header column `Mismatch (0/1)` to `RGD (0/1)` in **both** paths that must stay in sync: the Tools "Email Data" export (`ToolsViewController`) and the all-cycles pre-delete audit export (`CycleCSVExport`)
- **Tests** — updated the header pin and added `test_csvHeader_usesRGDLabel` / `test_csvHeader_dropsOldMismatchLabel`

## Backend unchanged (display-only)

The CKRecord column and the `mismatch` property, `CodingKeys`, and subscript keys all keep `"mismatch"`. Existing records, CloudKit, and historical CSV **data values** are unaffected — only the visible label and header text change.

## Testing

- `xcodebuild ... test` (iPhone 17, iOS 26.0.1): **67/67 passing, 0 failures**
- The backend `mismatch` key stays guarded by the existing `to()` round-trip test