### PR TITLE
Refactor pop-ups to a custom PopupAlertController for cross-iOS alignment

### DIFF
--- a/LocationApp/LocationApp.xcodeproj/project.pbxproj
+++ b/LocationApp/LocationApp.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		846606C121AA3CA00049814C /* ReadWriteText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846606C021AA3CA00049814C /* ReadWriteText.swift */; };
 		DA20260612000000000000B2 /* CycleCSVExport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA20260612000000000000B1 /* CycleCSVExport.swift */; };
 		DA20260617000000000000C2 /* SuperUserGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA20260617000000000000C1 /* SuperUserGate.swift */; };
+		DA20260618000000000000D2 /* PopupAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA20260618000000000000D1 /* PopupAlertController.swift */; };
+		DA20260618000000000000D4 /* AlertGalleryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA20260618000000000000D3 /* AlertGalleryViewController.swift */; };
 		846606C321AA5C380049814C /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846606C221AA5C380049814C /* MapViewController.swift */; };
 		84712D582597C874006F31E4 /* Briefcase.csv in Resources */ = {isa = PBXBuildFile; fileRef = 84712D572597C874006F31E4 /* Briefcase.csv */; };
 		84712D622597C9FA006F31E4 /* Version 1.2 Briefcase Flowchart.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 84712D612597C9FA006F31E4 /* Version 1.2 Briefcase Flowchart.pdf */; };
@@ -122,6 +124,8 @@
 		846606C021AA3CA00049814C /* ReadWriteText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadWriteText.swift; sourceTree = "<group>"; };
 		DA20260612000000000000B1 /* CycleCSVExport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CycleCSVExport.swift; sourceTree = "<group>"; };
 		DA20260617000000000000C1 /* SuperUserGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperUserGate.swift; sourceTree = "<group>"; };
+		DA20260618000000000000D1 /* PopupAlertController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupAlertController.swift; sourceTree = "<group>"; };
+		DA20260618000000000000D3 /* AlertGalleryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertGalleryViewController.swift; sourceTree = "<group>"; };
 		846606C221AA5C380049814C /* MapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewController.swift; sourceTree = "<group>"; };
 		846D6B4F2170160E008E003D /* LocationApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = LocationApp.entitlements; sourceTree = "<group>"; };
 		84712D572597C874006F31E4 /* Briefcase.csv */ = {isa = PBXFileReference; lastKnownFileType = text; path = Briefcase.csv; sourceTree = "<group>"; };
@@ -326,6 +330,8 @@
 			children = (
 				5CF01FDD22D92F19004604BC /* ToolsViewController.swift */,
 				DA20260617000000000000C1 /* SuperUserGate.swift */,
+				DA20260618000000000000D1 /* PopupAlertController.swift */,
+				DA20260618000000000000D3 /* AlertGalleryViewController.swift */,
 				DA20260611000000000000A1 /* DeleteOldCyclesViewController.swift */,
 				84571FE4258FE29C009AC936 /* BriefCase.swift */,
 				5CFF888A22CAA5B700611F60 /* ActiveLocations.swift */,
@@ -542,6 +548,8 @@
 				846606C121AA3CA00049814C /* ReadWriteText.swift in Sources */,
 				DA20260612000000000000B2 /* CycleCSVExport.swift in Sources */,
 				DA20260617000000000000C2 /* SuperUserGate.swift in Sources */,
+				DA20260618000000000000D2 /* PopupAlertController.swift in Sources */,
+				DA20260618000000000000D4 /* AlertGalleryViewController.swift in Sources */,
 				8487FE3021A8F9C700CC62E8 /* StartupViewController.swift in Sources */,
 				5E4D12742A2776E9002E4D91 /* Slac.swift in Sources */,
 				5A5EFD742A306ED500547EB8 /* SettingsService.swift in Sources */,

--- a/LocationApp/LocationApp/Base.lproj/Main.storyboard
+++ b/LocationApp/LocationApp/Base.lproj/Main.storyboard
@@ -168,14 +168,14 @@
                         <viewLayoutGuide key="safeArea" id="8cu-87-6eq"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="zZL-V9-XtT" firstAttribute="leading" secondItem="Kob-bg-1b1" secondAttribute="leading" id="1jI-fL-FlG"/>
+                            <constraint firstItem="zZL-V9-XtT" firstAttribute="leading" secondItem="8cu-87-6eq" secondAttribute="leading" id="1jI-fL-FlG"/>
                             <constraint firstItem="zZL-V9-XtT" firstAttribute="top" secondItem="8cu-87-6eq" secondAttribute="top" id="9D7-13-zaz"/>
                             <constraint firstItem="RcM-5r-EfG" firstAttribute="top" secondItem="iL3-Xk-1J0" secondAttribute="bottom" constant="40" id="KyH-ds-r7E"/>
                             <constraint firstItem="P1C-rk-auY" firstAttribute="leading" secondItem="8cu-87-6eq" secondAttribute="centerX" constant="-95" id="PP0-4v-SJE"/>
                             <constraint firstItem="8cu-87-6eq" firstAttribute="centerX" secondItem="08g-6x-YOH" secondAttribute="trailing" constant="-90" id="S1g-c1-bTk"/>
                             <constraint firstItem="iL3-Xk-1J0" firstAttribute="top" secondItem="08g-6x-YOH" secondAttribute="bottom" constant="40" id="U3h-PD-cLz"/>
                             <constraint firstItem="08g-6x-YOH" firstAttribute="leading" secondItem="8cu-87-6eq" secondAttribute="centerX" constant="-90" id="YhT-6g-vci"/>
-                            <constraint firstAttribute="trailing" secondItem="zZL-V9-XtT" secondAttribute="trailing" id="b7D-Z6-DRt"/>
+                            <constraint firstItem="8cu-87-6eq" firstAttribute="trailing" secondItem="zZL-V9-XtT" secondAttribute="trailing" id="b7D-Z6-DRt"/>
                             <constraint firstItem="RcM-5r-EfG" firstAttribute="leading" secondItem="8cu-87-6eq" secondAttribute="centerX" constant="-90" id="btq-o1-rUX"/>
                             <constraint firstItem="iL3-Xk-1J0" firstAttribute="trailing" secondItem="8cu-87-6eq" secondAttribute="centerX" constant="80" id="dUa-8w-h9i"/>
                             <constraint firstItem="8cu-87-6eq" firstAttribute="bottom" secondItem="3FX-rC-9sw" secondAttribute="bottom" constant="20" id="dVq-SL-gBz"/>
@@ -275,8 +275,8 @@
                         <constraints>
                             <constraint firstItem="Q3R-xK-h38" firstAttribute="leading" secondItem="3vx-ua-3CT" secondAttribute="leading" constant="6" id="6dP-BT-Ft2"/>
                             <constraint firstItem="Z2k-es-NAn" firstAttribute="bottom" secondItem="LZq-Hw-VfF" secondAttribute="bottom" id="ECg-kh-GUf"/>
-                            <constraint firstItem="hLD-RW-VpW" firstAttribute="leading" secondItem="LZq-Hw-VfF" secondAttribute="leading" id="Go1-8e-vG8"/>
-                            <constraint firstAttribute="trailing" secondItem="hLD-RW-VpW" secondAttribute="trailing" id="Ii7-ob-g0O"/>
+                            <constraint firstItem="hLD-RW-VpW" firstAttribute="leading" secondItem="3vx-ua-3CT" secondAttribute="leading" id="Go1-8e-vG8"/>
+                            <constraint firstItem="3vx-ua-3CT" firstAttribute="trailing" secondItem="hLD-RW-VpW" secondAttribute="trailing" id="Ii7-ob-g0O"/>
                             <constraint firstItem="Q3R-xK-h38" firstAttribute="top" secondItem="hLD-RW-VpW" secondAttribute="bottom" constant="7" id="R3D-e2-e7Y"/>
                             <constraint firstItem="hLD-RW-VpW" firstAttribute="trailing" secondItem="Z2k-es-NAn" secondAttribute="trailing" id="aKQ-t9-H6B"/>
                             <constraint firstItem="Q3R-xK-h38" firstAttribute="centerX" secondItem="LZq-Hw-VfF" secondAttribute="centerX" id="oZZ-m4-DeW"/>
@@ -651,7 +651,7 @@
                             <constraint firstItem="NbT-RM-wwD" firstAttribute="centerX" secondItem="rGX-4s-oH0" secondAttribute="centerX" id="DyM-RO-zUE"/>
                             <constraint firstItem="Lcj-N0-aBJ" firstAttribute="centerX" secondItem="EKo-E9-4qz" secondAttribute="centerX" id="G0e-Cn-bBS"/>
                             <constraint firstItem="ryS-kA-Lja" firstAttribute="leading" secondItem="rGX-4s-oH0" secondAttribute="leading" constant="3" id="G4W-4U-0Yq"/>
-                            <constraint firstItem="Lcj-N0-aBJ" firstAttribute="leading" secondItem="EKo-E9-4qz" secondAttribute="leading" id="Gpo-q6-vAs"/>
+                            <constraint firstItem="Lcj-N0-aBJ" firstAttribute="leading" secondItem="rGX-4s-oH0" secondAttribute="leading" id="Gpo-q6-vAs"/>
                             <constraint firstItem="rGX-4s-oH0" firstAttribute="trailing" secondItem="cQi-M6-zkx" secondAttribute="trailing" constant="15" id="I1Y-73-rAB"/>
                             <constraint firstItem="1Rf-N1-EDl" firstAttribute="trailing" secondItem="Lcj-N0-aBJ" secondAttribute="trailing" id="Sf8-ia-xOu"/>
                             <constraint firstItem="ryS-kA-Lja" firstAttribute="trailing" secondItem="rGX-4s-oH0" secondAttribute="trailing" constant="-3" id="WZj-b0-ij9"/>
@@ -1009,10 +1009,10 @@
                             <constraint firstItem="BRE-vb-1za" firstAttribute="bottom" secondItem="YWk-fq-veD" secondAttribute="bottom" id="HrJ-MU-uzc"/>
                             <constraint firstItem="H7a-rn-D7h" firstAttribute="centerX" secondItem="YWk-fq-veD" secondAttribute="centerX" id="J7G-Uv-66l"/>
                             <constraint firstItem="KZB-5t-5Ps" firstAttribute="bottom" secondItem="YWk-fq-veD" secondAttribute="bottom" id="Jbv-dO-8sS"/>
-                            <constraint firstAttribute="trailing" secondItem="YVj-t4-aS4" secondAttribute="trailing" id="JfM-ei-MWL"/>
+                            <constraint firstItem="eeG-p5-3Ip" firstAttribute="trailing" secondItem="YVj-t4-aS4" secondAttribute="trailing" id="JfM-ei-MWL"/>
                             <constraint firstItem="gEB-YD-oqx" firstAttribute="leading" secondItem="eeG-p5-3Ip" secondAttribute="leading" constant="80" id="NpJ-cB-2JV"/>
                             <constraint firstItem="KZB-5t-5Ps" firstAttribute="trailing" secondItem="YWk-fq-veD" secondAttribute="trailing" id="Whe-9G-03n"/>
-                            <constraint firstItem="YVj-t4-aS4" firstAttribute="leading" secondItem="YWk-fq-veD" secondAttribute="leading" id="Xe6-cE-hGx"/>
+                            <constraint firstItem="YVj-t4-aS4" firstAttribute="leading" secondItem="eeG-p5-3Ip" secondAttribute="leading" id="Xe6-cE-hGx"/>
                             <constraint firstItem="BRE-vb-1za" firstAttribute="trailing" secondItem="eeG-p5-3Ip" secondAttribute="trailing" id="ZxX-xZ-j52"/>
                             <constraint firstItem="N2q-Tp-62q" firstAttribute="leading" secondItem="eeG-p5-3Ip" secondAttribute="leading" constant="17" id="aC1-EP-ce1"/>
                             <constraint firstItem="gEB-YD-oqx" firstAttribute="top" secondItem="N2q-Tp-62q" secondAttribute="bottom" constant="63" id="aI3-Zb-rnj"/>

--- a/LocationApp/LocationApp/StartupViewController.swift
+++ b/LocationApp/LocationApp/StartupViewController.swift
@@ -107,8 +107,25 @@ class StartupViewController: UIViewController, MFMailComposeViewControllerDelega
             print("Unable to start notifier")
         }  //end catch
         //end Detect Wifi...
-        
+
+        #if DEBUG
+        // Debug-only: long-press the version label to open the alert gallery for
+        // on-device QA of every pop-up. Excluded from release builds.
+        let galleryPress = UILongPressGestureRecognizer(target: self, action: #selector(showAlertGallery))
+        versionLabel.isUserInteractionEnabled = true
+        versionLabel.addGestureRecognizer(galleryPress)
+        #endif
+
     } //end viewDidLoad
+
+    #if DEBUG
+    @objc private func showAlertGallery(_ gesture: UILongPressGestureRecognizer) {
+        guard gesture.state == .began else { return }
+        let gallery = UINavigationController(rootViewController: AlertGalleryViewController())
+        gallery.modalPresentationStyle = .fullScreen
+        present(gallery, animated: true)
+    }
+    #endif
     
     
     override func viewDidAppear(_ animated: Bool) {

--- a/LocationApp/LocationAppTests/LocationAppTests.swift
+++ b/LocationApp/LocationAppTests/LocationAppTests.swift
@@ -1101,4 +1101,34 @@ class LocationAppTests: XCTestCase {
         fields.first?.sendActions(for: .editingChanged)
         XCTAssertEqual(reported, "lab 12", "Editing should report the new text via onChange")
     }
+
+    // The Deploy popup (alert8) carries two independent switch rows — Moderator
+    // (variables.moderator) and RGD (variables.mismatch) — each reporting only its
+    // own flips; a cross-wire would corrupt the other field. Order matches alert8.
+    func test_popup_twoSwitchesAreIndependent() {
+        var moderatorReported: Bool?
+        var rgdReported: Bool?
+        let popup = PopupAlertController(title: "Deploy Dosimeter:", message: "\nLocation: BLG 044-004")
+        popup.addTextField(text: "ryans office", placeholder: "Location") { _ in }
+        popup.addSwitch(title: "Moderator", isOn: false) { moderatorReported = $0 }
+        popup.addSwitch(title: "RGD", isOn: true) { rgdReported = $0 }
+        popup.addAction(PopupAction(title: "Save"))
+        popup.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+        popup.view.layoutIfNeeded()
+
+        let found = switches(in: popup.view)
+        XCTAssertEqual(found.count, 2, "Deploy should render exactly two UISwitches")
+        XCTAssertEqual(found.first?.isOn, false, "Moderator should reflect its initial off state")
+        XCTAssertEqual(found.last?.isOn, true, "RGD should reflect its initial on state")
+
+        found.first?.isOn = true
+        found.first?.sendActions(for: .valueChanged)
+        XCTAssertEqual(moderatorReported, true, "Flipping Moderator should fire only its onChange")
+        XCTAssertNil(rgdReported, "Flipping Moderator must not fire RGD's onChange")
+
+        found.last?.isOn = false
+        found.last?.sendActions(for: .valueChanged)
+        XCTAssertEqual(rgdReported, false, "Flipping RGD should fire its onChange with the new value")
+        XCTAssertEqual(moderatorReported, true, "RGD's flip must not disturb the Moderator value")
+    }
 }

--- a/LocationApp/LocationAppTests/LocationAppTests.swift
+++ b/LocationApp/LocationAppTests/LocationAppTests.swift
@@ -961,6 +961,23 @@ class LocationAppTests: XCTestCase {
                        "Each PopupAction should render one button, in the order added")
     }
 
+    // The simple scanner alerts (alert1/alert2 etc.) are now PopupAlertControllers
+    // with a title, no message, and two buttons. A nil message must not drop the
+    // title or the buttons — guards the native-alert conversion.
+    func test_popup_titleOnlyWithTwoActionsBuildsBothButtonsAndTitle() {
+        let popup = PopupAlertController(title: "Dosimeter Not Found:\n21111111116", message: nil)
+        popup.addAction(PopupAction(title: "Deploy"))
+        popup.addAction(PopupAction(title: "Cancel", style: .cancel))
+        popup.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+        popup.view.layoutIfNeeded()
+
+        let titles = buttons(in: popup.view).map { $0.title(for: .normal) }
+        XCTAssertEqual(titles, ["Deploy", "Cancel"],
+                       "A title-only popup should still build both buttons in order")
+        let hasTitle = labels(in: popup.view).contains { ($0.text ?? "").hasPrefix("Dosimeter Not Found") }
+        XCTAssertTrue(hasTitle, "The title must render even when the message is nil")
+    }
+
     func test_popup_buildsWithASingleActionAndImage() {
         let popup = PopupAlertController(title: "Scan Accepted", message: "Please scan.")
         popup.setImage(UIImage())

--- a/LocationApp/LocationAppTests/LocationAppTests.swift
+++ b/LocationApp/LocationAppTests/LocationAppTests.swift
@@ -363,7 +363,7 @@ class LocationAppTests: XCTestCase {
                        "Newest first, with the nil-createdDate record sorted last")
     }
 
-    // MARK: - buildDateString (SOW 2.4: auto-derived Tools build date)
+    // MARK: - buildDateString (auto-derived Tools build date)
 
     func test_buildDateString_formatsAsMonthCommaYear() {
         // 2023-05-15 12:00 UTC — mid-month, so no timezone boundary ambiguity.
@@ -380,13 +380,11 @@ class LocationAppTests: XCTestCase {
         XCTAssertEqual(ToolsViewController.buildDateString(from: date), "May, 2023")
     }
 
-    // MARK: - Settings fallback coordinates (SOW R3-a: offline scan, no GPS fix)
+    // MARK: - Settings fallback coordinates (offline scan, no GPS fix)
 
-    // Devices in the field have a cached Settings JSON written before the
-    // coordinate fields existed. They must stay decodable — the fields are
-    // optional for exactly this reason — and the accessor must fall back to the
-    // SOW R3 coordinate. If decode ever starts failing here, shipping it would
-    // break every already-deployed cache.
+    // Field devices have a cached Settings JSON written before the coordinate
+    // fields existed; it must stay decodable (the fields are optional) and the
+    // accessor must fall back to the built-in coordinate.
     func test_settingsDecode_withoutCoordinateFields_succeedsAndUsesFallback() throws {
         let oldFormat = #"{"dosimeterMinimumLength": 11, "dosimeterMaximumLength": 11}"#
 
@@ -928,5 +926,179 @@ class LocationAppTests: XCTestCase {
 
         XCTAssertTrue((startup.statusLabel.gestureRecognizers ?? []).isEmpty,
                       "the hidden tap-to-refresh gesture should be removed from the status label")
+    }
+
+    // MARK: - PopupAlertController (custom cross-iOS alert)
+
+    // Collects every UIButton in a view tree so a built popup can be inspected
+    // without reaching into its private subviews.
+    private func buttons(in view: UIView) -> [UIButton] {
+        view.subviews.reduce(into: []) { result, subview in
+            if let button = subview as? UIButton { result.append(button) }
+            result.append(contentsOf: buttons(in: subview))
+        }
+    }
+
+    func test_popupAction_storesItsFieldsAndDefaultsToNormalStyle() {
+        var fired = false
+        let action = PopupAction(title: "OK") { fired = true }
+
+        XCTAssertEqual(action.title, "OK")
+        XCTAssertEqual(action.style, .normal, "Style should default to .normal when omitted")
+
+        action.handler?()
+        XCTAssertTrue(fired, "Invoking the stored handler should run the closure")
+    }
+
+    func test_popup_buildsOneButtonPerActionInOrder() {
+        let popup = PopupAlertController(title: "Title", message: "Message")
+        popup.addAction(PopupAction(title: "Cancel", style: .cancel))
+        popup.addAction(PopupAction(title: "OK"))
+        popup.loadViewIfNeeded()
+
+        let titles = buttons(in: popup.view).map { $0.title(for: .normal) }
+        XCTAssertEqual(titles, ["Cancel", "OK"],
+                       "Each PopupAction should render one button, in the order added")
+    }
+
+    func test_popup_buildsWithASingleActionAndImage() {
+        let popup = PopupAlertController(title: "Scan Accepted", message: "Please scan.")
+        popup.setImage(UIImage())
+        popup.addAction(PopupAction(title: "OK"))
+        popup.loadViewIfNeeded()
+
+        XCTAssertEqual(buttons(in: popup.view).count, 1,
+                       "A single-action popup with an image should still build exactly one button")
+    }
+
+    // Finds the popup's rounded card — the view setBackgroundColor tints — by its
+    // distinctive corner radius, so the test never touches a private property.
+    private func cardView(in view: UIView) -> UIView? {
+        if view.layer.cornerRadius == 13.5 { return view }
+        for subview in view.subviews {
+            if let found = cardView(in: subview) { return found }
+        }
+        return nil
+    }
+
+    func test_popup_defaultsToSystemBackgroundWhenNoColorSet() {
+        let popup = PopupAlertController(title: "Title", message: "Message")
+        popup.addAction(PopupAction(title: "OK"))
+        popup.loadViewIfNeeded()
+
+        XCTAssertEqual(cardView(in: popup.view)?.backgroundColor, .systemBackground,
+                       "The card should use the system background when no color is set")
+    }
+
+    func test_popup_setBackgroundColorTintsTheCard() {
+        let popup = PopupAlertController(title: "Warning", message: "Message")
+        popup.setBackgroundColor(.yellow)
+        popup.addAction(PopupAction(title: "OK"))
+        popup.loadViewIfNeeded()
+
+        XCTAssertEqual(cardView(in: popup.view)?.backgroundColor, .yellow,
+                       "setBackgroundColor should tint the card, replacing the old private-subview hack")
+    }
+
+    func test_popup_setBackgroundColorIgnoresNil() {
+        let popup = PopupAlertController(title: "Warning", message: "Message")
+        popup.setBackgroundColor(nil)
+        popup.addAction(PopupAction(title: "OK"))
+        popup.loadViewIfNeeded()
+
+        XCTAssertEqual(cardView(in: popup.view)?.backgroundColor, .systemBackground,
+                       "Passing nil should leave the default system background intact")
+    }
+
+    // Collects every UILabel in a view tree so a laid-out popup can be inspected.
+    private func labels(in view: UIView) -> [UILabel] {
+        view.subviews.reduce(into: []) { result, subview in
+            if let label = subview as? UILabel { result.append(label) }
+            result.append(contentsOf: labels(in: subview))
+        }
+    }
+
+    // Regression for the zero-height scroll view: the title/message sit in a
+    // UIScrollView that collapsed to 0pt and clipped them. After a real layout
+    // pass the title and message must have non-zero height.
+    func test_popup_titleAndMessageLayOutWithNonZeroHeight() {
+        let popup = PopupAlertController(title: "Scan Accepted",
+                                         message: "Please scan the corresponding location code.")
+        popup.addAction(PopupAction(title: "OK"))
+        popup.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+        popup.view.layoutIfNeeded()
+
+        let content = labels(in: popup.view).filter {
+            $0.text == "Scan Accepted" || ($0.text?.hasPrefix("Please scan") ?? false)
+        }
+        XCTAssertEqual(content.count, 2, "Both the title and message labels should be present")
+        for label in content {
+            XCTAssertGreaterThan(label.bounds.height, 0,
+                                 "\"\(label.text ?? "")\" must lay out with non-zero height; a collapsed scroll view clips it")
+        }
+    }
+
+    // The popup pins to light so the card stays a known light background in any
+    // device mode — both for cross-mode consistency and so transparent-background
+    // images (e.g. the black-on-alpha QRCodeImage) don't vanish on a dark card.
+    func test_popup_pinsToLightAppearance() {
+        let popup = PopupAlertController(title: "Title", message: "Message")
+        popup.addAction(PopupAction(title: "OK"))
+        popup.loadViewIfNeeded()
+
+        XCTAssertEqual(popup.overrideUserInterfaceStyle, .light,
+                       "PopupAlertController should force light appearance")
+    }
+
+    private func switches(in view: UIView) -> [UISwitch] {
+        view.subviews.reduce(into: []) { result, subview in
+            if let toggle = subview as? UISwitch { result.append(toggle) }
+            result.append(contentsOf: switches(in: subview))
+        }
+    }
+
+    // The switch row (RGD on Exchange/Collect) must reflect the initial state
+    // and report flips, since that drives variables.mismatch in the scanner flow.
+    func test_popup_switchRowReflectsInitialStateAndReportsChanges() {
+        var reported: Bool?
+        let popup = PopupAlertController(title: "Exchange", message: "Cycle")
+        popup.addSwitch(title: "Mismatch", isOn: true) { reported = $0 }
+        popup.addAction(PopupAction(title: "Exchange"))
+        popup.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+        popup.view.layoutIfNeeded()
+
+        let found = switches(in: popup.view)
+        XCTAssertEqual(found.count, 1, "addSwitch should render exactly one UISwitch")
+        XCTAssertEqual(found.first?.isOn, true, "The switch should reflect the initial isOn state")
+
+        found.first?.isOn = false
+        found.first?.sendActions(for: .valueChanged)
+        XCTAssertEqual(reported, false, "Flipping the switch should fire onChange with the new value")
+    }
+
+    private func textFields(in view: UIView) -> [UITextField] {
+        view.subviews.reduce(into: []) { result, subview in
+            if let field = subview as? UITextField { result.append(field) }
+            result.append(contentsOf: textFields(in: subview))
+        }
+    }
+
+    // The text-field row (deploy location) must prefill from the initial value and
+    // report edits, since the scanner relies on that to track variables.dosiLocation.
+    func test_popup_textFieldReflectsInitialTextAndReportsEdits() {
+        var reported: String?
+        let popup = PopupAlertController(title: "Deploy", message: nil)
+        popup.addTextField(text: "ryans office", placeholder: "Location") { reported = $0 }
+        popup.addAction(PopupAction(title: "Save"))
+        popup.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+        popup.view.layoutIfNeeded()
+
+        let fields = textFields(in: popup.view)
+        XCTAssertEqual(fields.count, 1, "addTextField should render exactly one UITextField")
+        XCTAssertEqual(fields.first?.text, "ryans office", "The field should prefill with the initial text")
+
+        fields.first?.text = "lab 12"
+        fields.first?.sendActions(for: .editingChanged)
+        XCTAssertEqual(reported, "lab 12", "Editing should report the new text via onChange")
     }
 }

--- a/LocationApp/Map/MapViewController.swift
+++ b/LocationApp/Map/MapViewController.swift
@@ -156,126 +156,26 @@ extension MapViewController {
     
     //alert to filter pins
     func filtersAlert() {
-        
-        //configure alert message
-        let font1 = [NSAttributedString.Key.font: UIFont(name: "Arial-BoldMT", size: 22)!,
-                     NSAttributedString.Key.paragraphStyle: NSMutableParagraphStyle()]
-        let font2 = [NSAttributedString.Key.font: UIFont(name: "ArialMT", size: 18)!,
-                     NSAttributedString.Key.paragraphStyle: NSMutableParagraphStyle()]
-        let message = NSMutableAttributedString(string: "", attributes: font1)
-        message.append(NSAttributedString(string: "Active\n\n", attributes: font1))
-        message.append(NSAttributedString(string: "\tCurrent Cycle:\n\n\tPrior Cycle:\n\n\tNo Dosimeter:\n\n\n", attributes: font2))
-        message.append(NSAttributedString(string: "Inactive\n\n", attributes: font1))
-        message.append(NSAttributedString(string: "\tCurrent Cycle:\n\n\tPrior Cycle:\n\n\tNo Dosimeter:\n", attributes: font2))
-        
-        //set up alert
-        let alert = UIAlertController.init(title: nil, message: nil, preferredStyle: .alert)
-        alert.setValue(message, forKey: "attributedMessage")
-        let OK = UIAlertAction(title: "OK", style: .default, handler: handlerOK)
-        
-        alert.view.addSubview(redSwitch())
-        alert.view.addSubview(greenSwitch())
-        alert.view.addSubview(orangeSwitch())
-        alert.view.addSubview(purpleSwitch())
-        alert.view.addSubview(blueSwitch())
-        alert.view.addSubview(yellowSwitch())
-        alert.addAction(OK)
-        
+        // Switch rows replace six UISwitches floated at hardcoded frames over a
+        // UIAlertController whose body used the private attributedMessage KVC hack.
+        // Each switch's on-tint is the pin colour it filters; the label is the legend.
+        let alert = PopupAlertController(title: nil, message: nil)
+        alert.addSection(title: "Active")
+        alert.addSwitch(title: "Current Cycle:", isOn: filters[.red] ?? true, color: .red) { [weak self] in self?.filters[.red] = $0 }
+        alert.addSwitch(title: "Prior Cycle:", isOn: filters[.green] ?? true, color: .green) { [weak self] in self?.filters[.green] = $0 }
+        alert.addSwitch(title: "No Dosimeter:", isOn: filters[.orange] ?? false, color: .orange) { [weak self] in self?.filters[.orange] = $0 }
+        alert.addSection(title: "Inactive")
+        alert.addSwitch(title: "Current Cycle:", isOn: filters[.purple] ?? true, color: .purple) { [weak self] in self?.filters[.purple] = $0 }
+        alert.addSwitch(title: "Prior Cycle:", isOn: filters[.blue] ?? true, color: .blue) { [weak self] in self?.filters[.blue] = $0 }
+        alert.addSwitch(title: "No Dosimeter:", isOn: filters[.yellow] ?? false, color: .yellow) { [weak self] in self?.filters[.yellow] = $0 }
+        alert.addAction(PopupAction(title: "OK") { [weak self] in self?.handlerOK(alert: nil) })
+
         DispatchQueue.main.async {
             self.present(alert, animated: true, completion: nil)
         }
     }
     
     
-    //RED PINS - current cycle, active (stop)
-    func redSwitch() -> UISwitch {
-        let redSwitch = UISwitch(frame: CGRect(x: 170, y: 62, width: 0, height: 0))
-        redSwitch.onTintColor = UIColor.red
-        redSwitch.tintColor = UIColor.gray
-        redSwitch.setOn(filters[.red]!, animated: false)
-        redSwitch.addTarget(self, action: #selector(redSwitchDidChange(_:)), for: .valueChanged)
-        return redSwitch
-    }
-    
-    @objc func redSwitchDidChange(_ sender: UISwitch!) {
-        filters[.red] = sender.isOn
-    }
-    
-    //GREEN PINS - prior cycle, active (exchange)
-    func greenSwitch() -> UISwitch {
-        let greenSwitch = UISwitch(frame: CGRect(x: 170, y: 102, width: 0, height: 0))
-        greenSwitch.onTintColor = UIColor.green
-        greenSwitch.tintColor = UIColor.gray
-        greenSwitch.setOn(filters[.green]!, animated: false)
-        greenSwitch.addTarget(self, action: #selector(greenSwitchDidChange(_:)), for: .valueChanged)
-        return greenSwitch
-    }
-    
-    @objc func greenSwitchDidChange(_ sender: UISwitch!) {
-        filters[.green] = sender.isOn
-    }
-    
-    
-    //ORANGE PINS - active, no dosimeter (deploy)
-    func orangeSwitch() -> UISwitch {
-        let orangeSwitch = UISwitch(frame: CGRect(x: 170, y: 142, width: 0, height: 0))
-        orangeSwitch.onTintColor = UIColor.orange
-        orangeSwitch.tintColor = UIColor.gray
-        orangeSwitch.setOn(filters[.orange]!, animated: false)
-        orangeSwitch.addTarget(self, action: #selector(orangeSwitchDidChange(_:)), for: .valueChanged)
-        return orangeSwitch
-    }
-    
-    @objc func orangeSwitchDidChange(_ sender: UISwitch!) {
-        filters[.orange] = sender.isOn
-    }
-    
-    
-    //PURPLE PINS - current cycle, inactive (stop)
-    func purpleSwitch() -> UISwitch {
-        let purpleSwitch = UISwitch(frame: CGRect(x: 170, y: 251, width: 0, height: 0))
-        purpleSwitch.onTintColor = UIColor.purple
-        purpleSwitch.tintColor = UIColor.gray
-        purpleSwitch.setOn(filters[.purple]!, animated: false)
-        purpleSwitch.addTarget(self, action: #selector(purpleSwitchDidChange(_:)), for: .valueChanged)
-        return purpleSwitch
-    }
-    
-    @objc func purpleSwitchDidChange(_ sender: UISwitch!) {
-        filters[.purple] = sender.isOn
-    }
-    
-    
-    //BLUE PINS - prior cycle, inactive (collect)
-    func blueSwitch() -> UISwitch {
-        let blueSwitch = UISwitch(frame: CGRect(x: 170, y: 291, width: 0, height: 0))
-        blueSwitch.onTintColor = UIColor.blue
-        blueSwitch.tintColor = UIColor.gray
-        blueSwitch.setOn(filters[.blue]!, animated: false)
-        blueSwitch.addTarget(self, action: #selector(blueSwitchDidChange(_:)), for: .valueChanged)
-        return blueSwitch
-    }
-    
-    @objc func blueSwitchDidChange(_ sender: UISwitch!) {
-        filters[.blue] = sender.isOn
-    }
-    
-    
-    //YELLOW PINS - inactive, no dosimeter
-    func yellowSwitch() -> UISwitch {
-        let yellowSwitch = UISwitch(frame: CGRect(x: 170, y: 331, width: 0, height: 0))
-        yellowSwitch.onTintColor = UIColor.yellow
-        yellowSwitch.tintColor = UIColor.gray
-        yellowSwitch.setOn(filters[.yellow]!, animated: false)
-        yellowSwitch.addTarget(self, action: #selector(yellowSwitchDidChange(_:)), for: .valueChanged)
-        return yellowSwitch
-    }
-    
-    @objc func yellowSwitchDidChange(_ sender: UISwitch!) {
-        filters[.yellow] = sender.isOn
-    }
-    
-
     func handlerOK(alert: UIAlertAction!) {
         self.activityIndicator.startAnimating()
         queryForMap()

--- a/LocationApp/Scanner/ScannerViewController.swift
+++ b/LocationApp/Scanner/ScannerViewController.swift
@@ -129,8 +129,8 @@ class ScannerViewController: UIViewController, AVCaptureMetadataOutputObjectsDel
     
     func failed() {
         
-        let ac = UIAlertController(title: "Scanning not supported", message: "Your device does not support scanning a code from an item. Please use a device with a camera.", preferredStyle: .alert)
-        ac.addAction(UIAlertAction(title: "OK", style: .default))
+        let ac = PopupAlertController(title: "Scanning not supported", message: "Your device does not support scanning a code from an item. Please use a device with a camera.")
+        ac.addAction(PopupAction(title: "OK"))
         present(ac, animated: true)
         captureSession = nil
         
@@ -702,15 +702,14 @@ extension ScannerViewController {  //alerts
     
     func alert1() {
         
-        let alert = UIAlertController(title: "Dosimeter Not Found:\n\(variables.dosiNumber ?? "Nil Dosi")", message: nil, preferredStyle: .alert)
-        let cancel = UIAlertAction(title: "Cancel", style: .cancel, handler: handlerCancel)
-        
-        let deployDosimeter = UIAlertAction(title: "Deploy", style: .default) { (_) in
+        let alert = PopupAlertController(title: "Dosimeter Not Found:\n\(variables.dosiNumber ?? "Nil Dosi")", message: nil)
+        let deployDosimeter = PopupAction(title: "Deploy") { [weak self] in
             variables.QRCode = nil
-            self.deploy()
-            self.alert4()
+            self?.deploy()
+            self?.alert4()
         } //end let
-        
+        let cancel = PopupAction(title: "Cancel", style: .cancel) { [weak self] in self?.handlerCancel(alert: nil) }
+
         alert.addAction(deployDosimeter)
         alert.addAction(cancel)
         
@@ -724,15 +723,14 @@ extension ScannerViewController {  //alerts
         
         let title = itemRecord != nil ? "Location Found:\n\(variables.QRCode ?? "Nil QRCode")" : "New Location:\n\(variables.QRCode ?? "Nil QRCode")"
         
-        let alert = UIAlertController(title: title, message: nil, preferredStyle: .alert)
-        let cancel = UIAlertAction(title: "Cancel", style: .cancel, handler: handlerCancel)
-        
-        let deployDosimeter = UIAlertAction(title: "Deploy", style: .default) { (_) in
+        let alert = PopupAlertController(title: title, message: nil)
+        let deployDosimeter = PopupAction(title: "Deploy") { [weak self] in
             variables.dosiNumber = nil
-            self.deploy()
-            self.alert5()
+            self?.deploy()
+            self?.alert5()
         } //end let
-        
+        let cancel = PopupAction(title: "Cancel", style: .cancel) { [weak self] in self?.handlerCancel(alert: nil) }
+
         alert.addAction(deployDosimeter)
         alert.addAction(cancel)
         
@@ -747,9 +745,9 @@ extension ScannerViewController {  //alerts
         let message = "Please activate this location to deploy a dosimeter."
         
         //set up alert
-        let alert = UIAlertController.init(title: "Inactive Location:\n\(variables.QRCode ?? "Nil QRCode")", message: message, preferredStyle: .alert)
-        let OK = UIAlertAction(title: "OK", style: .default, handler: handlerCancel)
-        
+        let alert = PopupAlertController(title: "Inactive Location:\n\(variables.QRCode ?? "Nil QRCode")", message: message)
+        let OK = PopupAction(title: "OK") { [weak self] in self?.handlerCancel(alert: nil) }
+
         alert.addAction(OK)
         
         DispatchQueue.main.async {
@@ -979,9 +977,9 @@ extension ScannerViewController {  //alerts
         let message = "Please scan either a location barcode or a dosimeter."
         
         //set up alert
-        let alert = UIAlertController.init(title: "Invalid Barcode Type", message: message, preferredStyle: .alert)
-        let OK = UIAlertAction(title: "OK", style: .cancel, handler: handlerCancel)
-        
+        let alert = PopupAlertController(title: "Invalid Barcode Type", message: message)
+        let OK = PopupAction(title: "OK", style: .cancel) { [weak self] in self?.handlerCancel(alert: nil) }
+
         alert.addAction(OK)
         
         DispatchQueue.main.async {
@@ -995,8 +993,8 @@ extension ScannerViewController {  //alerts
         let message = "This dosimeter has already been collected."
         
         //set up alert
-        let alert = UIAlertController.init(title: "Invalid Dosimeter:\n\(variables.dosiNumber ?? "Nil Dosi")", message: message, preferredStyle: .alert)
-        let OK = UIAlertAction(title: "OK", style: .cancel, handler: handlerCancel)
+        let alert = PopupAlertController(title: "Invalid Dosimeter:\n\(variables.dosiNumber ?? "Nil Dosi")", message: message)
+        let OK = PopupAction(title: "OK", style: .cancel) { [weak self] in self?.handlerCancel(alert: nil) }
         alert.addAction(OK)
         
         DispatchQueue.main.async {
@@ -1012,9 +1010,9 @@ extension ScannerViewController {  //alerts
         let message = "QR Code: \(variables.QRCode ?? "Nil QRCode")\nDosimeter: \(variables.dosiNumber ?? "Nil Dosi")"
         
         //set up alert
-        let alert = UIAlertController.init(title: "Save Successful!", message: message, preferredStyle: .alert)
-        let OK = UIAlertAction(title: "OK", style: .default, handler: handlerCancel)
-        
+        let alert = PopupAlertController(title: "Save Successful!", message: message)
+        let OK = PopupAction(title: "OK") { [weak self] in self?.handlerCancel(alert: nil) }
+
         alert.addAction(OK)
         
         DispatchQueue.main.async {
@@ -1030,9 +1028,9 @@ extension ScannerViewController {  //alerts
         let message = "QR Code: \(variables.QRCode ?? "Nil QRCode")\nDosimeter: \(variables.dosiNumber ?? "Nil Dosi")"
         
         //set up alert
-        let alert = UIAlertController.init(title: "Collection Successful!", message: message, preferredStyle: .alert)
-        let OK = UIAlertAction(title: "OK", style: .default, handler: handlerCancel)
-        
+        let alert = PopupAlertController(title: "Collection Successful!", message: message)
+        let OK = PopupAction(title: "OK") { [weak self] in self?.handlerCancel(alert: nil) }
+
         alert.addAction(OK)
         
         DispatchQueue.main.async {
@@ -1048,14 +1046,14 @@ extension ScannerViewController {  //alerts
         let message = "QR Code: \(variables.QRCode ?? "Nil QRCode")\nDosimeter: \(variables.dosiNumber ?? "Nil Dosi")"
         
         //set up alert
-        let alert = UIAlertController.init(title: "Collection Successful!", message: message, preferredStyle: .alert)
-        let OK = UIAlertAction(title: "OK", style: .default) { (_) in
-            self.deploy()
+        let alert = PopupAlertController(title: "Collection Successful!", message: message)
+        let OK = PopupAction(title: "OK") { [weak self] in
+            self?.deploy()
             variables.mismatch = 0
             variables.dosiNumber = nil
-            self.alert3()
+            self?.alert3()
         }
-        
+
         alert.addAction(OK)
         
         DispatchQueue.main.async {
@@ -1069,14 +1067,14 @@ extension ScannerViewController {  //alerts
         let message = "Invalid barcode, please rescan!"
         
         //set up alert
-        let alert = UIAlertController.init(title: "Invalid code", message: message, preferredStyle: .alert)
-        let rescan = UIAlertAction(title: "Rescan", style: .default) { (_) in
-            self.isRescan = true
+        let alert = PopupAlertController(title: "Invalid code", message: message)
+        let rescan = PopupAction(title: "Rescan") { [weak self] in
+            self?.isRescan = true
             DispatchQueue.global(qos: .background).async {
-                self.captureSession.startRunning()
+                self?.captureSession.startRunning()
             }
         }
-        
+
         alert.addAction(rescan)
         
         DispatchQueue.main.async {
@@ -1111,14 +1109,14 @@ extension ScannerViewController {  //alerts
         self.audioPlayer?.beepFail()
         
         //set up alert
-        let alert = UIAlertController.init(title: "Invalid length", message: message, preferredStyle: .alert)
-        let rescan = UIAlertAction(title: "Rescan", style: .default) { (_) in
-            self.isRescan = true
+        let alert = PopupAlertController(title: "Invalid length", message: message)
+        let rescan = PopupAction(title: "Rescan") { [weak self] in
+            self?.isRescan = true
             DispatchQueue.global(qos: .background).async {
-                self.captureSession.startRunning()
+                self?.captureSession.startRunning()
             }
         }
-        
+
         alert.addAction(rescan)
         
         DispatchQueue.main.async {
@@ -1132,19 +1130,16 @@ extension ScannerViewController {  //alerts
         
         self.audioPlayer?.beepFail()
         
-        let alert = UIAlertController(title: "GPS Coordinate Error\n", message: message, preferredStyle: .alert)
-        
-        let tryAgain = UIAlertAction(title: "Try Again", style: .cancel){ (_) in
-            self.save()
+        let alert = PopupAlertController(title: "GPS Coordinate Error", message: message)
+
+        let tryAgain = PopupAction(title: "Try Again", style: .cancel) { [weak self] in
+            self?.save()
         }
-        
+
         alert.addAction(tryAgain)
-        
+
         DispatchQueue.main.async {   //UIAlerts need to be shown on the main thread.
-            
-            self.present(alert, animated: true){
-                alert.view.superview?.subviews[0].isUserInteractionEnabled = false
-            }
+            self.present(alert, animated: true, completion: nil)
         }
     } //end alert15
     

--- a/LocationApp/Scanner/ScannerViewController.swift
+++ b/LocationApp/Scanner/ScannerViewController.swift
@@ -760,24 +760,18 @@ extension ScannerViewController {  //alerts
     func alert3a() {
         
         let message = "\nCycle Date: \(variables.cycle ?? "Nil Cycle")"
-        let alert = UIAlertController(title: "Exchange Dosimeter:\n\(variables.dosiNumber ?? "Nil Dosi")\n\nLocation:\n\(variables.QRCode ?? "Nil QRCode")", message: message, preferredStyle: .alert)
-        let cancel = UIAlertAction(title: "Cancel", style: .cancel, handler: handlerCancel)
-        
-        let ExchangeDosimeter = UIAlertAction(title: "Exchange", style: .default) { (_) in
-            self.collect(collected: 1, mismatch: variables.mismatch ?? 0, modifiedDate: Date(timeInterval: 0, since: Date()))
-            self.alert11a()
-        }
-        
-        let mismatch = UIAlertAction(title: "RGD", style: .default) { (_) in
-            self.alert3a()
-        }
-        
-        alert.addAction(mismatch)
-        alert.view.addSubview(mismatchSwitch())
-        alert.addAction(ExchangeDosimeter)
-        alert.addAction(cancel)
-        
-        DispatchQueue.main.async { //UIAlerts need to be shown on the main thread.
+        let alert = PopupAlertController(title: "Exchange Dosimeter:\n\(variables.dosiNumber ?? "Nil Dosi")\n\nLocation:\n\(variables.QRCode ?? "Nil QRCode")", message: message)
+        // The RGD toggle is now a proper switch row, replacing the old combo of an
+        // RGD reopen-action with a UISwitch floated at a fixed frame. The backend
+        // mismatch key is unchanged.
+        alert.addSwitch(title: "RGD", isOn: variables.mismatch == 1) { variables.mismatch = $0 ? 1 : 0 }
+        alert.addAction(PopupAction(title: "Exchange") { [weak self] in
+            self?.collect(collected: 1, mismatch: variables.mismatch ?? 0, modifiedDate: Date(timeInterval: 0, since: Date()))
+            self?.alert11a()
+        })
+        alert.addAction(PopupAction(title: "Cancel", style: .cancel) { [weak self] in self?.handlerCancel(alert: nil) })
+
+        DispatchQueue.main.async {
             self.present(alert, animated: true, completion: nil)
         }
     } //end alert3a
@@ -786,44 +780,30 @@ extension ScannerViewController {  //alerts
     func alert3i() {
         
         let message = "\nCycle Date: \(variables.cycle ?? "Nil Cycle")"
-        let alert = UIAlertController(title: "Collect Dosimeter:\n\(variables.dosiNumber ?? "Nil Dosi")\n\nLocation:\n\(variables.QRCode ?? "Nil QRCode")", message: message, preferredStyle: .alert)
-        let cancel = UIAlertAction(title: "Cancel", style: .cancel, handler: handlerCancel)
-        
-        let collectDosimeter = UIAlertAction(title: "Collect", style: .default) { (_) in
-            self.collect(collected: 1, mismatch: variables.mismatch ?? 0, modifiedDate: Date(timeInterval: 0, since: Date()))
-            self.alert11()
-        }
-        
-        let mismatch = UIAlertAction(title: "RGD", style: .default) { (_) in
-            self.alert3i() //reopen alert
-        }
-        
-        alert.addAction(mismatch)
-        alert.view.addSubview(mismatchSwitch())
-        alert.addAction(collectDosimeter)
-        alert.addAction(cancel)
-        
-        DispatchQueue.main.async { //UIAlerts need to be shown on the main thread.
+        let alert = PopupAlertController(title: "Collect Dosimeter:\n\(variables.dosiNumber ?? "Nil Dosi")\n\nLocation:\n\(variables.QRCode ?? "Nil QRCode")", message: message)
+        // RGD toggle as a switch row, replacing the floated-UISwitch hack. The
+        // backend mismatch key is unchanged.
+        alert.addSwitch(title: "RGD", isOn: variables.mismatch == 1) { variables.mismatch = $0 ? 1 : 0 }
+        alert.addAction(PopupAction(title: "Collect") { [weak self] in
+            self?.collect(collected: 1, mismatch: variables.mismatch ?? 0, modifiedDate: Date(timeInterval: 0, since: Date()))
+            self?.alert11()
+        })
+        alert.addAction(PopupAction(title: "Cancel", style: .cancel) { [weak self] in self?.handlerCancel(alert: nil) })
+
+        DispatchQueue.main.async {
             self.present(alert, animated: true, completion: nil)
         }
-        
+
     } //end alert3i
     
     
     func alert3() {
         
-        let message = "Please scan the new dosimeter for location \(variables.QRCode ?? "Nil Dosi").\n\n\n\n\n\n\n"
-        let picture = Bundle.main.path(forResource: "Inlight", ofType: "jpg")!
-        let imageView = UIImageView(frame: CGRect(x: 75, y: 90, width: 120, height: 80))
-        let image = UIImage(named: picture)
-        imageView.image = image
-        
-        //set up alert
-        let alert = UIAlertController.init(title: "Replace Dosimeter", message: message, preferredStyle: .alert)
-        let OK = UIAlertAction(title: "OK", style: .default, handler: handlerOK)
-        alert.view.addSubview(imageView)
-        alert.addAction(OK)
-        
+        let message = "Please scan the new dosimeter for location \(variables.QRCode ?? "Nil Dosi")."
+        let alert = PopupAlertController(title: "Replace Dosimeter", message: message)
+        alert.setImage(scannerImage(named: "Inlight", ofType: "jpg"))
+        alert.addAction(PopupAction(title: "OK") { [weak self] in self?.handlerOK(alert: nil) })
+
         DispatchQueue.main.async {
             self.present(alert, animated: true, completion: nil)
         }
@@ -832,19 +812,11 @@ extension ScannerViewController {  //alerts
     
     func alert4() {
         
-        let message = "Dosimeter barcode accepted \(variables.dosiNumber ?? "Nil Dosi"). Please scan the corresponding location code.\n\n\n\n\n\n\n"
-        let picture = Bundle.main.path(forResource: "QRCodeImage", ofType: "png")!
-        let imageView = UIImageView(frame: CGRect(x: 90, y: 90, width: 100, height: 100))
-        let image = UIImage(named: picture)
-        imageView.image = image
-        
-        //set up alert
-        let alert = UIAlertController.init(title: "Scan Accepted", message: message, preferredStyle: .alert)
-        let OK = UIAlertAction(title: "OK", style: .default, handler: handlerOK)
-        
-        alert.view.addSubview(imageView)
-        alert.addAction(OK)
-        
+        let message = "Dosimeter barcode accepted \(variables.dosiNumber ?? "Nil Dosi"). Please scan the corresponding location code."
+        let alert = PopupAlertController(title: "Scan Accepted", message: message)
+        alert.setImage(scannerImage(named: "QRCodeImage", ofType: "png"))
+        alert.addAction(PopupAction(title: "OK") { [weak self] in self?.handlerOK(alert: nil) })
+
         DispatchQueue.main.async {
             self.present(alert, animated: true, completion: nil)
         }
@@ -853,19 +825,11 @@ extension ScannerViewController {  //alerts
     
     func alert5() {
         
-        let message = "Location code accepted \(variables.QRCode ?? "Nil QR"). Please scan the corresponding dosimeter.\n\n\n\n\n\n"
-        let picture = Bundle.main.path(forResource: "Inlight", ofType: "jpg")!
-        let imageView = UIImageView(frame: CGRect(x: 75, y: 100, width: 120, height: 80))
-        let image = UIImage(named: picture)
-        imageView.image = image
-        
-        //set up alert
-        let alert = UIAlertController.init(title: "Scan Accepted", message: message, preferredStyle: .alert)
-        let OK = UIAlertAction(title: "OK", style: .default, handler: handlerOK)
-        
-        alert.view.addSubview(imageView)
-        alert.addAction(OK)
-        
+        let message = "Location code accepted \(variables.QRCode ?? "Nil QR"). Please scan the corresponding dosimeter."
+        let alert = PopupAlertController(title: "Scan Accepted", message: message)
+        alert.setImage(scannerImage(named: "Inlight", ofType: "jpg"))
+        alert.addAction(PopupAction(title: "OK") { [weak self] in self?.handlerOK(alert: nil) })
+
         DispatchQueue.main.async {
             self.present(alert, animated: true, completion: nil)
         }
@@ -874,19 +838,11 @@ extension ScannerViewController {  //alerts
     
     func alert6a() {
         
-        let message = "Try again...Please scan the corresponding location code.\n\n\n\n\n\n\n"
-        let picture = Bundle.main.path(forResource: "QRCodeImage", ofType: "png")!
-        let imageView = UIImageView(frame: CGRect(x: 90, y: 90, width: 100, height: 100))
-        let image = UIImage(named: picture)
-        imageView.image = image
-        
-        //set up alert
-        let alert = UIAlertController.init(title: "Error", message: message, preferredStyle: .alert)
-        let OK = UIAlertAction(title: "OK", style: .cancel, handler: handlerOK)
-        
-        alert.view.addSubview(imageView)
-        alert.addAction(OK)
-        
+        let message = "Try again...Please scan the corresponding location code."
+        let alert = PopupAlertController(title: "Error", message: message)
+        alert.setImage(scannerImage(named: "QRCodeImage", ofType: "png"))
+        alert.addAction(PopupAction(title: "OK", style: .cancel) { [weak self] in self?.handlerOK(alert: nil) })
+
         DispatchQueue.main.async {
             self.present(alert, animated: true, completion: nil)
         }
@@ -895,19 +851,11 @@ extension ScannerViewController {  //alerts
     
     func alert6b() {
         
-        let message = "Try again...Please scan the corresponding dosimeter.\n\n\n\n\n\n\n"
-        let picture = Bundle.main.path(forResource: "Inlight", ofType: "jpg")!
-        let imageView = UIImageView(frame: CGRect(x: 75, y: 90, width: 120, height: 80))
-        let image = UIImage(named: picture)
-        imageView.image = image
-        
-        //set up alert
-        let alert = UIAlertController.init(title: "Error", message: message, preferredStyle: .alert)
-        let OK = UIAlertAction(title: "OK", style: .cancel, handler: handlerOK)
-        
-        alert.view.addSubview(imageView)
-        alert.addAction(OK)
-        
+        let message = "Try again...Please scan the corresponding dosimeter."
+        let alert = PopupAlertController(title: "Error", message: message)
+        alert.setImage(scannerImage(named: "Inlight", ofType: "jpg"))
+        alert.addAction(PopupAction(title: "OK", style: .cancel) { [weak self] in self?.handlerOK(alert: nil) })
+
         DispatchQueue.main.async {
             self.present(alert, animated: true, completion: nil)
         }
@@ -916,19 +864,11 @@ extension ScannerViewController {  //alerts
     
     func alert7a(code: String) {
         
-        let message = "Try again...Please scan a new dosimeter.\n\n\n\n\n\n\n"
-        let picture = Bundle.main.path(forResource: "Inlight", ofType: "jpg")!
-        let imageView = UIImageView(frame: CGRect(x: 75, y: 110, width: 120, height: 80))
-        let image = UIImage(named: picture)
-        imageView.image = image
-        
-        //set up alert
-        let alert = UIAlertController.init(title: "Duplicate Dosimeter:\n\(code)", message: message, preferredStyle: .alert)
-        let OK = UIAlertAction(title: "OK", style: .cancel, handler: handlerOK)
-        
-        alert.view.addSubview(imageView)
-        alert.addAction(OK)
-        
+        let message = "Try again...Please scan a new dosimeter."
+        let alert = PopupAlertController(title: "Duplicate Dosimeter:\n\(code)", message: message)
+        alert.setImage(scannerImage(named: "Inlight", ofType: "jpg"))
+        alert.addAction(PopupAction(title: "OK", style: .cancel) { [weak self] in self?.handlerOK(alert: nil) })
+
         DispatchQueue.main.async {
             self.present(alert, animated: true, completion: nil)
         }
@@ -938,19 +878,11 @@ extension ScannerViewController {  //alerts
     func alert7b(code: String) {
         
         let title = variables.collected == 0 ? "Location In Use:\n\(code)" : "Inactive Location:\n\(variables.QRCode ?? "Nil QRCode")"
-        let message = "Try again...Please scan a different location.\n\n\n\n\n\n\n"
-        let picture = Bundle.main.path(forResource: "QRCodeImage", ofType: "png")!
-        let imageView = UIImageView(frame: CGRect(x: 90, y: 110, width: 100, height: 100))
-        let image = UIImage(named: picture)
-        imageView.image = image
-        
-        //set up alert
-        let alert = UIAlertController.init(title: title, message: message, preferredStyle: .alert)
-        let OK = UIAlertAction(title: "OK", style: .cancel, handler: handlerOK)
-        
-        alert.view.addSubview(imageView)
-        alert.addAction(OK)
-        
+        let message = "Try again...Please scan a different location."
+        let alert = PopupAlertController(title: title, message: message)
+        alert.setImage(scannerImage(named: "QRCodeImage", ofType: "png"))
+        alert.addAction(PopupAction(title: "OK", style: .cancel) { [weak self] in self?.handlerOK(alert: nil) })
+
         DispatchQueue.main.async {
             self.present(alert, animated: true, completion: nil)
         }
@@ -958,119 +890,84 @@ extension ScannerViewController {  //alerts
     
     //MARK:  Alert8
     func alert8() {
-        let alert = UIAlertController(title: "Deploy Dosimeter:\n\(variables.dosiNumber ?? "Nil Dosi")", message: "\nLocation: \(variables.QRCode ?? "Nil QRCode")", preferredStyle: .alert)
-        
-        let moderator = UIAlertAction(title: "Moderator", style: .default) { (_) in
-            if let tempDesc = alert.textFields?.first?.text {
-                variables.dosiLocation = tempDesc
-            }
-            self.alert8()
+        let alert = PopupAlertController(title: "Deploy Dosimeter:\n\(variables.dosiNumber ?? "Nil Dosi")",
+                                         message: "\nLocation: \(variables.QRCode ?? "Nil QRCode")")
+        // Location field and Moderator toggle are now proper rows. The field writes
+        // variables.dosiLocation on every edit, so Save and the camera flow read the
+        // current value without the old reopen-the-alert hack or a floated UISwitch.
+        alert.addTextField(text: variables.dosiLocation, placeholder: "Type or dictate location details") {
+            variables.dosiLocation = $0
         }
-        
-        let saveRecord = UIAlertAction(title: "Save", style: .default) { (_) in
-            if let text = alert.textFields?.first?.text {
-                let label = UILabel(frame: CGRect(x: 0, y: 97, width: 270, height:18))
-                label.textAlignment = .center
-                label.textColor = .red
-                //label.font = label.font.withSize(12)
-                label.font = .boldSystemFont(ofSize: 14)
-                alert.view.addSubview(label)
-                label.isHidden = true
-                if text == ""{
-                    label.text = "Please enter a location"
-                    label.isHidden = false
-                    self.present(alert, animated: true, completion: nil)
-                } else if variables.QRCode == nil {
-                    // Hardening (SOW V2 Rev 1): refuse to deploy a location whose
-                    // QR code never got captured. Saving here would persist the
-                    // "Nil QRCode" placeholder to CloudKit (see setValue below),
-                    // which can't be reconciled later. Bounce back to the scanner
-                    // so the field worker rescans the location QR code.
-                    let qrError = UIAlertController(title: "Location QR Code Missing", message: "The location QR code wasn't captured. Please scan the location QR code again before deploying.", preferredStyle: .alert)
-                    qrError.addAction(UIAlertAction(title: "OK", style: .default, handler: self.handlerCancel))
-                    DispatchQueue.main.async {
-                        self.present(qrError, animated: true, completion: nil)
-                    }
-                } else {
-                    let description = text.replacingOccurrences(of: ",", with: "-")
-                    let newRecord = CKRecord(recordType: "Location")
-                    newRecord.setValue(variables.latitude ?? "Nil Latitude", forKey: "latitude")
-                    newRecord.setValue(variables.longitude ?? "Nil Longitude", forKey: "longitude")
-                    newRecord.setValue(description, forKey: "locdescription")
-                    newRecord.setValue(variables.dosiNumber ?? "Nil Dosi", forKey: "dosinumber")
-                    newRecord.setValue(0, forKey: "collectedFlag")
-                    newRecord.setValue(variables.cycle, forKey: "cycleDate")
-                    newRecord.setValue(variables.QRCode ?? "Nil QRCode", forKey: "QRCode")
-                    newRecord.setValue(variables.moderator ?? 0, forKey: "moderator")
-                    newRecord.setValue(1, forKey: "active")
-                    newRecord.setValue(Date(timeInterval: 0, since: Date()), forKey: "createdDate")
-                    newRecord.setValue(Date(timeInterval: 0, since: Date()), forKey: "modifiedDate")
-                    newRecord.setValue(variables.mismatch ?? 0, forKey: "mismatch")
-                    
-                    if let qrCode =  variables.QRCode {
-                        let reportGroup = Groups[qrCode]
-                        newRecord.setValue(reportGroup, forKey: "reportGroup")
-                    }
-                    
-                    var locationRecordCacheItem = LocationRecordCacheItem(withRecord: newRecord)!
-                    
-                    if let photo = self.photo {
-                        do {
-                            try locationRecordCacheItem.setPhoto(photo: photo)
-                           
-                        } catch {
-                            print("Unexpected error: \(error).")
-                        }
-                    }
-                    
-                    self.locations.save(item: locationRecordCacheItem, completionHandler: nil)
-                    
-                    self.photo = nil
-                    
-                    self.outOfRangeCounter = 0
-                    
-                    self.alert10() //Succes
-                }
-                
-                //text = text?.replacingOccurrences(of: ",", with: "-")
-                //Ver 1.2 - supply default location to prevent empty string in DB.
-                //rather than alert on top of alert for field valication
-                //if text == "" {
-                //   text = "Default Location (field left empty)"
-                
-            } //end if let
-            
-            
-        }  //end let
-        
-        let cancel = UIAlertAction(title: "Cancel", style: .cancel, handler: handlerCancel)
-        
-        alert.addTextField { (textfield) in
-            if variables.dosiLocation != nil {
-                textfield.text = variables.dosiLocation // assign self.description with the textfield information
-            }
-            textfield.placeholder = "Type or dictate location details" //assign self.description with the textfield information
-        } // end addTextField
-        
-        alert.addAction(moderator)
-        alert.view.addSubview(modSwitch())
-       
-        if(reachability.isReachable){
-            let photo = UIAlertAction(title: (self.photo == nil) ? "Add photo" : "Replace photo", style: .default, handler: {(action) in
-                let tempDesc = alert.textFields?.first?.text
-                self.openCamera(tempDesc: tempDesc)
+        alert.addSwitch(title: "Moderator", isOn: variables.moderator == 1) { variables.moderator = $0 ? 1 : 0 }
+        if reachability.isReachable {
+            alert.addAction(PopupAction(title: (self.photo == nil) ? "Add photo" : "Replace photo") { [weak self] in
+                self?.openCamera(tempDesc: variables.dosiLocation)
             })
-            alert.addAction(photo)
         }
-        
-        alert.addAction(saveRecord)
-        alert.addAction(cancel)
-       
-        DispatchQueue.main.async {   //UIAlerts need to be shown on the main thread.
+        alert.addAction(PopupAction(title: "Save") { [weak self] in self?.saveDeployedLocation() })
+        alert.addAction(PopupAction(title: "Cancel", style: .cancel) { [weak self] in self?.handlerCancel(alert: nil) })
+
+        DispatchQueue.main.async {
             self.present(alert, animated: true, completion: nil)
         }
-        
     }  //end alert8
+
+    // Validates and saves a deployed location from alert8. An empty location or a
+    // missing QR code each bounce to an explanatory popup instead of saving.
+    func saveDeployedLocation() {
+        let text = variables.dosiLocation ?? ""
+        if text.isEmpty {
+            let prompt = PopupAlertController(title: "Location Required", message: "Please enter a location.")
+            prompt.addAction(PopupAction(title: "OK") { [weak self] in self?.alert8() })
+            DispatchQueue.main.async { self.present(prompt, animated: true, completion: nil) }
+            return
+        }
+        if variables.QRCode == nil {
+            // Refuse to deploy a location whose QR code never got captured. Saving
+            // the "Nil QRCode" placeholder can't be reconciled later, so bounce back
+            // to the scanner to rescan.
+            let qrError = PopupAlertController(title: "Location QR Code Missing",
+                                               message: "The location QR code wasn't captured. Please scan the location QR code again before deploying.")
+            qrError.addAction(PopupAction(title: "OK") { [weak self] in self?.handlerCancel(alert: nil) })
+            DispatchQueue.main.async { self.present(qrError, animated: true, completion: nil) }
+            return
+        }
+
+        let description = text.replacingOccurrences(of: ",", with: "-")
+        let newRecord = CKRecord(recordType: "Location")
+        newRecord.setValue(variables.latitude ?? "Nil Latitude", forKey: "latitude")
+        newRecord.setValue(variables.longitude ?? "Nil Longitude", forKey: "longitude")
+        newRecord.setValue(description, forKey: "locdescription")
+        newRecord.setValue(variables.dosiNumber ?? "Nil Dosi", forKey: "dosinumber")
+        newRecord.setValue(0, forKey: "collectedFlag")
+        newRecord.setValue(variables.cycle, forKey: "cycleDate")
+        newRecord.setValue(variables.QRCode ?? "Nil QRCode", forKey: "QRCode")
+        newRecord.setValue(variables.moderator ?? 0, forKey: "moderator")
+        newRecord.setValue(1, forKey: "active")
+        newRecord.setValue(Date(timeInterval: 0, since: Date()), forKey: "createdDate")
+        newRecord.setValue(Date(timeInterval: 0, since: Date()), forKey: "modifiedDate")
+        newRecord.setValue(variables.mismatch ?? 0, forKey: "mismatch")
+
+        if let qrCode = variables.QRCode {
+            let reportGroup = Groups[qrCode]
+            newRecord.setValue(reportGroup, forKey: "reportGroup")
+        }
+
+        var locationRecordCacheItem = LocationRecordCacheItem(withRecord: newRecord)!
+
+        if let photo = self.photo {
+            do {
+                try locationRecordCacheItem.setPhoto(photo: photo)
+            } catch {
+                print("Unexpected error: \(error).")
+            }
+        }
+
+        self.locations.save(item: locationRecordCacheItem, completionHandler: nil)
+        self.photo = nil
+        self.outOfRangeCounter = 0
+        self.alert10() //Success
+    }
     
     
     func alert9() {  //invalid barcode type
@@ -1187,20 +1084,12 @@ extension ScannerViewController {  //alerts
     func alert13(nextFunction: @escaping () -> Void) {  //invalid cycle date
         
         let message = "This dosimeter already exchanged in the current cycle. Are you sure you want to continue?"
-        
-        //set up alert
-        let alert = UIAlertController.init(title: "Warning", message: message, preferredStyle: .alert)
-        
-        alert.view.subviews.first?.subviews.first?.subviews.first?.backgroundColor = UIColor(named: "WarningDialogBackground")
-        
-        let cont = UIAlertAction(title: "Continue", style: .destructive) { (_) in
-            nextFunction()
-        }
-        let cancel = UIAlertAction(title: "Cancel", style: .cancel, handler: handlerCancel)
-        
-        alert.addAction(cont)
-        alert.addAction(cancel)
-        
+
+        let alert = PopupAlertController(title: "Warning", message: message)
+        alert.setBackgroundColor(UIColor(named: "WarningDialogBackground"))
+        alert.addAction(PopupAction(title: "Continue", style: .destructive) { nextFunction() })
+        alert.addAction(PopupAction(title: "Cancel", style: .cancel) { [weak self] in self?.handlerCancel(alert: nil) })
+
         DispatchQueue.main.async {
             self.present(alert, animated: true, completion: nil)
         }
@@ -1255,33 +1144,12 @@ extension ScannerViewController {  //alerts
         }
     } //end alert15
     
-    //mismatch switch
-    func mismatchSwitch() -> UISwitch {
-        let switchControl = UISwitch(frame: CGRect(x: 200, y: 191, width: 0, height: 0))
-        switchControl.tintColor = UIColor.gray
-        switchControl.setOn(variables.mismatch == 1, animated: false)
-        switchControl.addTarget(self, action: #selector(mismatchSwitchValueDidChange), for: .valueChanged)
-        return switchControl
+    //Loads a scanner alert image from the app bundle, or nil if it is missing.
+    func scannerImage(named name: String, ofType ext: String) -> UIImage? {
+        guard let path = Bundle.main.path(forResource: name, ofType: ext) else { return nil }
+        return UIImage(contentsOfFile: path)
     }
-    
-    @objc func mismatchSwitchValueDidChange(_ sender: UISwitch!) {
-        variables.mismatch = sender.isOn ? 1 : 0
-    }
-    
-    
-    //moderator switch
-    func modSwitch() -> UISwitch {
-        let switchControl = UISwitch(frame: CGRect(x: 200, y: 161, width: 0, height: 0))
-        switchControl.tintColor = UIColor.gray
-        switchControl.setOn(variables.moderator == 1, animated: false)
-        switchControl.addTarget(self, action: #selector(modSwitchValueDidChange), for: .valueChanged)
-        return switchControl
-    }
-    
-    @objc func modSwitchValueDidChange(_ sender: UISwitch!) {
-        variables.moderator = sender.isOn ? 1 : 0
-    }
-    
+
 }//end extension alerts
 
 /*

--- a/LocationApp/Scanner/ScannerViewController.swift
+++ b/LocationApp/Scanner/ScannerViewController.swift
@@ -892,13 +892,17 @@ extension ScannerViewController {  //alerts
     func alert8() {
         let alert = PopupAlertController(title: "Deploy Dosimeter:\n\(variables.dosiNumber ?? "Nil Dosi")",
                                          message: "\nLocation: \(variables.QRCode ?? "Nil QRCode")")
-        // Location field and Moderator toggle are now proper rows. The field writes
-        // variables.dosiLocation on every edit, so Save and the camera flow read the
-        // current value without the old reopen-the-alert hack or a floated UISwitch.
+        // Location field, Moderator toggle, and RGD toggle are proper rows. The field
+        // writes variables.dosiLocation on every edit, so Save and the camera flow read
+        // the current value without the old reopen-the-alert hack or a floated UISwitch.
         alert.addTextField(text: variables.dosiLocation, placeholder: "Type or dictate location details") {
             variables.dosiLocation = $0
         }
         alert.addSwitch(title: "Moderator", isOn: variables.moderator == 1) { variables.moderator = $0 ? 1 : 0 }
+        // RGD flags a dosimeter placed on a Radiation Generating Device. Same backend
+        // column (mismatch) as the Exchange/Collect RGD toggles; saveDeployedLocation
+        // already persists it.
+        alert.addSwitch(title: "RGD", isOn: variables.mismatch == 1) { variables.mismatch = $0 ? 1 : 0 }
         if reachability.isReachable {
             alert.addAction(PopupAction(title: (self.photo == nil) ? "Add photo" : "Replace photo") { [weak self] in
                 self?.openCamera(tempDesc: variables.dosiLocation)

--- a/LocationApp/Utility View/AlertGalleryViewController.swift
+++ b/LocationApp/Utility View/AlertGalleryViewController.swift
@@ -1,0 +1,249 @@
+//
+//  AlertGalleryViewController.swift
+//  LocationApp
+//
+//  Created by Daniel Spady on 6/18/26.
+//
+
+import UIKit
+
+// A debug-only catalog of every scanner pop-up so the alerts can be QA'd on a
+// device without walking the scan flow. Each row presents a placeholder copy whose
+// handlers only dismiss, so nothing here touches CloudKit or the scan state.
+final class AlertGalleryViewController: UIViewController {
+
+    // Stand-in values for the runtime interpolations (dosiNumber / QRCode).
+    private let dosi = "21111111116"
+    private let qr = "BLG 044-004"
+
+    private struct Demo {
+        let name: String
+        let make: () -> UIViewController
+    }
+
+    private struct Section {
+        let title: String
+        let demos: [Demo]
+    }
+
+    private let tableView = UITableView(frame: .zero, style: .insetGrouped)
+    private lazy var sections: [Section] = buildSections()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        if #available(iOS 13.0, *) { overrideUserInterfaceStyle = .light }
+        title = "Alert Gallery"
+        view.backgroundColor = .systemBackground
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done,
+                                                            target: self,
+                                                            action: #selector(close))
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+        view.addSubview(tableView)
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    @objc private func close() {
+        dismiss(animated: true)
+    }
+
+    private func bundleImage(_ name: String, _ ext: String) -> UIImage? {
+        guard let path = Bundle.main.path(forResource: name, ofType: ext) else { return nil }
+        return UIImage(contentsOfFile: path)
+    }
+
+    // Builds a PopupAlertController with handlers that only log, so tapping any
+    // button is side-effect free.
+    private func popup(title: String?,
+                       message: String?,
+                       image: UIImage? = nil,
+                       background: String? = nil,
+                       actions: [PopupAction]) -> UIViewController {
+        let alert = PopupAlertController(title: title, message: message)
+        if let image { alert.setImage(image) }
+        if let background { alert.setBackgroundColor(UIColor(named: background)) }
+        actions.forEach { alert.addAction($0) }
+        return alert
+    }
+
+    private func buildSections() -> [Section] {
+        let inlight = bundleImage("Inlight", "jpg")
+        let qrImage = bundleImage("QRCodeImage", "png")
+
+        let refactored = Section(title: "Refactored — new popup", demos: [
+            Demo(name: "alert3 · Replace Dosimeter") { [self] in
+                popup(title: "Replace Dosimeter",
+                      message: "Please scan the new dosimeter for location \(qr).",
+                      image: inlight,
+                      actions: [PopupAction(title: "OK")])
+            },
+            Demo(name: "alert4 · Scan Accepted (scan location)") { [self] in
+                popup(title: "Scan Accepted",
+                      message: "Dosimeter barcode accepted \(dosi). Please scan the corresponding location code.",
+                      image: qrImage,
+                      actions: [PopupAction(title: "OK")])
+            },
+            Demo(name: "alert5 · Scan Accepted (scan dosimeter)") { [self] in
+                popup(title: "Scan Accepted",
+                      message: "Location code accepted \(qr). Please scan the corresponding dosimeter.",
+                      image: inlight,
+                      actions: [PopupAction(title: "OK")])
+            },
+            Demo(name: "alert6a · Error (scan location)") { [self] in
+                popup(title: "Error",
+                      message: "Try again...Please scan the corresponding location code.",
+                      image: qrImage,
+                      actions: [PopupAction(title: "OK", style: .cancel)])
+            },
+            Demo(name: "alert6b · Error (scan dosimeter)") { [self] in
+                popup(title: "Error",
+                      message: "Try again...Please scan the corresponding dosimeter.",
+                      image: inlight,
+                      actions: [PopupAction(title: "OK", style: .cancel)])
+            },
+            Demo(name: "alert7a · Duplicate Dosimeter") { [self] in
+                popup(title: "Duplicate Dosimeter:\n\(dosi)",
+                      message: "Try again...Please scan a new dosimeter.",
+                      image: inlight,
+                      actions: [PopupAction(title: "OK", style: .cancel)])
+            },
+            Demo(name: "alert7b · Location In Use") { [self] in
+                popup(title: "Location In Use:\n\(qr)",
+                      message: "Try again...Please scan a different location.",
+                      image: qrImage,
+                      actions: [PopupAction(title: "OK", style: .cancel)])
+            },
+            Demo(name: "alert13 · Warning (already exchanged)") { [self] in
+                popup(title: "Warning",
+                      message: "This dosimeter already exchanged in the current cycle. Are you sure you want to continue?",
+                      background: "WarningDialogBackground",
+                      actions: [PopupAction(title: "Continue", style: .destructive),
+                                PopupAction(title: "Cancel", style: .cancel)])
+            },
+            Demo(name: "alert3a · Exchange Dosimeter (switch)") { [self] in
+                let alert = PopupAlertController(title: "Exchange Dosimeter:\n\(dosi)\n\nLocation:\n\(qr)",
+                                                 message: "\nCycle Date: 1-1-2026")
+                alert.addSwitch(title: "RGD", isOn: false) { _ in }
+                alert.addAction(PopupAction(title: "Exchange"))
+                alert.addAction(PopupAction(title: "Cancel", style: .cancel))
+                return alert
+            },
+            Demo(name: "alert3i · Collect Dosimeter (switch)") { [self] in
+                let alert = PopupAlertController(title: "Collect Dosimeter:\n\(dosi)\n\nLocation:\n\(qr)",
+                                                 message: "\nCycle Date: 1-1-2026")
+                alert.addSwitch(title: "RGD", isOn: false) { _ in }
+                alert.addAction(PopupAction(title: "Collect"))
+                alert.addAction(PopupAction(title: "Cancel", style: .cancel))
+                return alert
+            },
+            Demo(name: "alert8 · Deploy Dosimeter (text + switch)") { [self] in
+                let alert = PopupAlertController(title: "Deploy Dosimeter:\n\(dosi)", message: "\nLocation: \(qr)")
+                alert.addTextField(text: "ryans office", placeholder: "Type or dictate location details") { _ in }
+                alert.addSwitch(title: "Moderator", isOn: false) { _ in }
+                alert.addAction(PopupAction(title: "Add photo"))
+                alert.addAction(PopupAction(title: "Save"))
+                alert.addAction(PopupAction(title: "Cancel", style: .cancel))
+                return alert
+            },
+            Demo(name: "Map · Filter legend (6 colored switches)") {
+                let alert = PopupAlertController(title: nil, message: nil)
+                alert.addSection(title: "Active")
+                alert.addSwitch(title: "Current Cycle:", isOn: true, color: .red) { _ in }
+                alert.addSwitch(title: "Prior Cycle:", isOn: true, color: .green) { _ in }
+                alert.addSwitch(title: "No Dosimeter:", isOn: false, color: .orange) { _ in }
+                alert.addSection(title: "Inactive")
+                alert.addSwitch(title: "Current Cycle:", isOn: true, color: .purple) { _ in }
+                alert.addSwitch(title: "Prior Cycle:", isOn: true, color: .blue) { _ in }
+                alert.addSwitch(title: "No Dosimeter:", isOn: false, color: .yellow) { _ in }
+                alert.addAction(PopupAction(title: "OK"))
+                return alert
+            }
+        ])
+
+        let stress = Section(title: "Popup layout stress tests", demos: [
+            Demo(name: "Title only") { [self] in
+                popup(title: "Title Only", message: nil, actions: [PopupAction(title: "OK")])
+            },
+            Demo(name: "Long message (should scroll)") { [self] in
+                popup(title: "Long Message",
+                      message: String(repeating: "This message is intentionally long so the card hits its height cap and the content scrolls instead of pushing the buttons off-screen. ", count: 6),
+                      actions: [PopupAction(title: "OK")])
+            },
+            Demo(name: "Three actions") { [self] in
+                popup(title: "Three Actions",
+                      message: "Buttons should stack vertically with hairlines between them.",
+                      actions: [PopupAction(title: "Option A"),
+                                PopupAction(title: "Option B"),
+                                PopupAction(title: "Cancel", style: .cancel)])
+            },
+            Demo(name: "Destructive + Cancel (no image)") { [self] in
+                popup(title: "Delete?",
+                      message: "Destructive should be red, Cancel should be bold.",
+                      actions: [PopupAction(title: "Delete", style: .destructive),
+                                PopupAction(title: "Cancel", style: .cancel)])
+            },
+            Demo(name: "Tall image + long message") { [self] in
+                popup(title: "Image + Text",
+                      message: "Image sits between the message and the buttons, capped at 90pt tall.",
+                      image: inlight,
+                      actions: [PopupAction(title: "OK")])
+            }
+        ])
+
+        let native = Section(title: "Native (not yet refactored — for comparison)", demos: [
+            Demo(name: "alert1 · Dosimeter Not Found") { [self] in
+                let alert = UIAlertController(title: "Dosimeter Not Found:\n\(dosi)", message: nil, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "Deploy", style: .default))
+                alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+                return alert
+            },
+            Demo(name: "alert9 · Save Successful") { [self] in
+                let alert = UIAlertController(title: "Save Successful!", message: "QR Code: \(qr)\nDosimeter: \(dosi)", preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "OK", style: .default))
+                return alert
+            },
+            Demo(name: "alert15 · GPS Coordinate Error") {
+                let alert = UIAlertController(title: "GPS Coordinate Error\n", message: "Your fix is not on SLAC property.  Please tap Try Again.", preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "Try Again", style: .cancel))
+                return alert
+            }
+        ])
+
+        return [refactored, stress, native]
+    }
+}
+
+extension AlertGalleryViewController: UITableViewDataSource, UITableViewDelegate {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        sections.count
+    }
+
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        sections[section].title
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        sections[section].demos.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
+        cell.textLabel?.text = sections[indexPath.section].demos[indexPath.row].name
+        cell.textLabel?.numberOfLines = 0
+        cell.accessoryType = .disclosureIndicator
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        present(sections[indexPath.section].demos[indexPath.row].make(), animated: true)
+    }
+}

--- a/LocationApp/Utility View/AlertGalleryViewController.swift
+++ b/LocationApp/Utility View/AlertGalleryViewController.swift
@@ -143,10 +143,11 @@ final class AlertGalleryViewController: UIViewController {
                 alert.addAction(PopupAction(title: "Cancel", style: .cancel))
                 return alert
             },
-            Demo(name: "alert8 · Deploy Dosimeter (text + switch)") { [self] in
+            Demo(name: "alert8 · Deploy Dosimeter (text + 2 switches)") { [self] in
                 let alert = PopupAlertController(title: "Deploy Dosimeter:\n\(dosi)", message: "\nLocation: \(qr)")
                 alert.addTextField(text: "ryans office", placeholder: "Type or dictate location details") { _ in }
                 alert.addSwitch(title: "Moderator", isOn: false) { _ in }
+                alert.addSwitch(title: "RGD", isOn: false) { _ in }
                 alert.addAction(PopupAction(title: "Add photo"))
                 alert.addAction(PopupAction(title: "Save"))
                 alert.addAction(PopupAction(title: "Cancel", style: .cancel))

--- a/LocationApp/Utility View/AlertGalleryViewController.swift
+++ b/LocationApp/Utility View/AlertGalleryViewController.swift
@@ -198,26 +198,64 @@ final class AlertGalleryViewController: UIViewController {
             }
         ])
 
-        let native = Section(title: "Native (not yet refactored — for comparison)", demos: [
+        // Plain title/message/button alerts, now PopupAlertController too so the whole
+        // scan flow shares one look. These have no images or switches to lay out.
+        let simple = Section(title: "Refactored — simple alerts", demos: [
             Demo(name: "alert1 · Dosimeter Not Found") { [self] in
-                let alert = UIAlertController(title: "Dosimeter Not Found:\n\(dosi)", message: nil, preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: "Deploy", style: .default))
-                alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
-                return alert
+                popup(title: "Dosimeter Not Found:\n\(dosi)", message: nil,
+                      actions: [PopupAction(title: "Deploy"),
+                                PopupAction(title: "Cancel", style: .cancel)])
             },
-            Demo(name: "alert9 · Save Successful") { [self] in
-                let alert = UIAlertController(title: "Save Successful!", message: "QR Code: \(qr)\nDosimeter: \(dosi)", preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: "OK", style: .default))
-                return alert
+            Demo(name: "alert2 · New Location (deploy/cancel)") { [self] in
+                popup(title: "New Location:\n\(qr)", message: nil,
+                      actions: [PopupAction(title: "Deploy"),
+                                PopupAction(title: "Cancel", style: .cancel)])
             },
-            Demo(name: "alert15 · GPS Coordinate Error") {
-                let alert = UIAlertController(title: "GPS Coordinate Error\n", message: "Your fix is not on SLAC property.  Please tap Try Again.", preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: "Try Again", style: .cancel))
-                return alert
+            Demo(name: "alert2a · Inactive Location") { [self] in
+                popup(title: "Inactive Location:\n\(qr)",
+                      message: "Please activate this location to deploy a dosimeter.",
+                      actions: [PopupAction(title: "OK")])
+            },
+            Demo(name: "alert9 · Invalid Barcode Type") { [self] in
+                popup(title: "Invalid Barcode Type",
+                      message: "Please scan either a location barcode or a dosimeter.",
+                      actions: [PopupAction(title: "OK", style: .cancel)])
+            },
+            Demo(name: "alert9a · Invalid Dosimeter") { [self] in
+                popup(title: "Invalid Dosimeter:\n\(dosi)",
+                      message: "This dosimeter has already been collected.",
+                      actions: [PopupAction(title: "OK", style: .cancel)])
+            },
+            Demo(name: "alert10 · Save Successful") { [self] in
+                popup(title: "Save Successful!", message: "QR Code: \(qr)\nDosimeter: \(dosi)",
+                      actions: [PopupAction(title: "OK")])
+            },
+            Demo(name: "alert11 · Collection Successful") { [self] in
+                popup(title: "Collection Successful!", message: "QR Code: \(qr)\nDosimeter: \(dosi)",
+                      actions: [PopupAction(title: "OK")])
+            },
+            Demo(name: "alert12 · Invalid code (rescan)") { [self] in
+                popup(title: "Invalid code", message: "Invalid barcode, please rescan!",
+                      actions: [PopupAction(title: "Rescan")])
+            },
+            Demo(name: "alert14 · Invalid length (rescan)") { [self] in
+                popup(title: "Invalid length",
+                      message: "The length of the dosimeter barcodes must be 8 characters. Please rescan!",
+                      actions: [PopupAction(title: "Rescan")])
+            },
+            Demo(name: "alert15 · GPS Coordinate Error") { [self] in
+                popup(title: "GPS Coordinate Error",
+                      message: "Your fix is not on SLAC property.  Please tap Try Again.",
+                      actions: [PopupAction(title: "Try Again", style: .cancel)])
+            },
+            Demo(name: "Scanning not supported") { [self] in
+                popup(title: "Scanning not supported",
+                      message: "Your device does not support scanning a code from an item. Please use a device with a camera.",
+                      actions: [PopupAction(title: "OK")])
             }
         ])
 
-        return [refactored, stress, native]
+        return [refactored, simple, stress]
     }
 }
 

--- a/LocationApp/Utility View/PopupAlertController.swift
+++ b/LocationApp/Utility View/PopupAlertController.swift
@@ -1,0 +1,354 @@
+//
+//  PopupAlertController.swift
+//  LocationApp
+//
+//  Created by Daniel Spady on 6/18/26.
+//
+
+import UIKit
+
+//A button in a PopupAlertController, mirroring UIAlertAction's title/style/handler.
+struct PopupAction {
+    enum Style {
+        case normal
+        case cancel
+        case destructive
+    }
+
+    let title: String
+    let style: Style
+    let handler: (() -> Void)?
+
+    init(title: String, style: Style = .normal, handler: (() -> Void)? = nil) {
+        self.title = title
+        self.style = style
+        self.handler = handler
+    }
+}
+
+//A centered, Auto-Layout alert that replaces the UIAlertControllers which floated
+//an image or switch at hardcoded frames (mis-rendered as the system alert metrics
+//changed). Title/message/actions keep UIAlertController semantics.
+final class PopupAlertController: UIViewController {
+
+    //A labeled on/off row shown above the buttons (e.g. the RGD toggle).
+    //onChange fires on every flip; the popup stays open since only buttons dismiss.
+    private struct SwitchSpec {
+        let title: String
+        let isOn: Bool
+        let color: UIColor?
+        let onChange: (Bool) -> Void
+    }
+
+    //A single-line text input row (e.g. the deploy location field). onChange fires
+    //on every edit so callers track the value without reaching back into the popup.
+    private struct TextFieldSpec {
+        let text: String?
+        let placeholder: String?
+        let onChange: (String) -> Void
+    }
+
+    //Content rows are rendered in the order they're added, so sections, switches,
+    //and a text field can interleave (e.g. the map legend's Active/Inactive groups).
+    private enum ContentItem {
+        case section(String)
+        case toggle(SwitchSpec)
+        case textField(TextFieldSpec)
+    }
+
+    private let popupTitle: String?
+    private let popupMessage: String?
+    private var image: UIImage?
+    private var actions: [PopupAction] = []
+    private var contentItems: [ContentItem] = []
+    private var cardColor: UIColor = .systemBackground
+
+    private let card = UIView()
+    private let contentStack = UIStackView()
+    private var cardCenterY: NSLayoutConstraint?
+
+    init(title: String?, message: String?) {
+        self.popupTitle = title
+        self.popupMessage = message
+        super.init(nibName: nil, bundle: nil)
+        modalPresentationStyle = .overFullScreen
+        modalTransitionStyle = .crossDissolve
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("PopupAlertController is created in code, not from a coder")
+    }
+
+    //Sets the picture shown between the message and the buttons. No image = no row.
+    func setImage(_ image: UIImage?) {
+        self.image = image
+    }
+
+    //Tints the card (e.g. the yellow warning dialog). nil keeps the default
+    //system background. This replaces reaching into UIAlertController's private
+    //subview tree to recolor it, which broke as that tree changed across iOS.
+    func setBackgroundColor(_ color: UIColor?) {
+        if let color { cardColor = color }
+    }
+
+    func addAction(_ action: PopupAction) {
+        actions.append(action)
+    }
+
+    //Adds a labeled switch row between the content and the buttons. Replaces the
+    //old pattern of floating a UISwitch onto the alert at a hardcoded frame. color
+    //sets the on-tint (e.g. the map legend's red/green/orange/... swatches).
+    func addSwitch(title: String, isOn: Bool, color: UIColor? = nil, onChange: @escaping (Bool) -> Void) {
+        contentItems.append(.toggle(SwitchSpec(title: title, isOn: isOn, color: color, onChange: onChange)))
+    }
+
+    //Adds a bold, left-aligned section header (e.g. the map legend's "Active").
+    func addSection(title: String) {
+        contentItems.append(.section(title))
+    }
+
+    //Adds a single-line text field row. onChange fires on every edit.
+    func addTextField(text: String?, placeholder: String?, onChange: @escaping (String) -> Void) {
+        contentItems.append(.textField(TextFieldSpec(text: text, placeholder: placeholder, onChange: onChange)))
+    }
+
+    private var hasTextField: Bool {
+        contentItems.contains { if case .textField = $0 { return true } else { return false } }
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Pin to light like the rest of the app so the card stays a light background
+        // in any mode — consistent across iOS, and transparent-background images
+        // (QRCodeImage.png is a black QR on alpha) stay visible instead of vanishing.
+        overrideUserInterfaceStyle = .light
+        view.backgroundColor = UIColor.black.withAlphaComponent(0.4)
+        buildCard()
+        if hasTextField { observeKeyboard() }
+    }
+
+    private func buildCard() {
+        card.translatesAutoresizingMaskIntoConstraints = false
+        card.backgroundColor = cardColor
+        card.layer.cornerRadius = 13.5
+        card.clipsToBounds = true
+        view.addSubview(card)
+
+        let margin = view.safeAreaLayoutGuide
+        let centerY = card.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        cardCenterY = centerY
+        NSLayoutConstraint.activate([
+            card.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            centerY,
+            card.widthAnchor.constraint(equalToConstant: 270),
+            card.topAnchor.constraint(greaterThanOrEqualTo: margin.topAnchor, constant: 20),
+            card.bottomAnchor.constraint(lessThanOrEqualTo: margin.bottomAnchor, constant: -20)
+        ])
+
+        //The card stacks a scrollable content area over the button area, so long
+        //messages or a tall image scroll instead of pushing the buttons off screen.
+        let outerStack = UIStackView()
+        outerStack.translatesAutoresizingMaskIntoConstraints = false
+        outerStack.axis = .vertical
+        card.addSubview(outerStack)
+        NSLayoutConstraint.activate([
+            outerStack.topAnchor.constraint(equalTo: card.topAnchor),
+            outerStack.leadingAnchor.constraint(equalTo: card.leadingAnchor),
+            outerStack.trailingAnchor.constraint(equalTo: card.trailingAnchor),
+            outerStack.bottomAnchor.constraint(equalTo: card.bottomAnchor)
+        ])
+
+        outerStack.addArrangedSubview(buildContentScrollView())
+        outerStack.addArrangedSubview(buildButtons())
+    }
+
+    private func buildContentScrollView() -> UIScrollView {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+
+        contentStack.axis = .vertical
+        contentStack.spacing = 8
+        contentStack.alignment = .fill
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
+        contentStack.isLayoutMarginsRelativeArrangement = true
+        contentStack.directionalLayoutMargins = .init(top: 19, leading: 16, bottom: 19, trailing: 16)
+
+        if let popupTitle, !popupTitle.isEmpty {
+            contentStack.addArrangedSubview(makeLabel(text: popupTitle,
+                                                      font: .boldSystemFont(ofSize: 17)))
+        }
+        if let popupMessage, !popupMessage.isEmpty {
+            contentStack.addArrangedSubview(makeLabel(text: popupMessage,
+                                                      font: .systemFont(ofSize: 13)))
+        }
+        if let image {
+            let imageView = UIImageView(image: image)
+            imageView.contentMode = .scaleAspectFit
+            imageView.heightAnchor.constraint(equalToConstant: 90).isActive = true
+            contentStack.addArrangedSubview(imageView)
+        }
+        for item in contentItems {
+            switch item {
+            case .section(let title):
+                contentStack.addArrangedSubview(makeSectionHeader(title))
+            case .toggle(let spec):
+                contentStack.addArrangedSubview(makeSwitchRow(for: spec))
+            case .textField(let spec):
+                contentStack.addArrangedSubview(makeTextFieldRow(for: spec))
+            }
+        }
+
+        scrollView.addSubview(contentStack)
+        let frame = scrollView.frameLayoutGuide
+        let content = scrollView.contentLayoutGuide
+        NSLayoutConstraint.activate([
+            contentStack.topAnchor.constraint(equalTo: content.topAnchor),
+            contentStack.leadingAnchor.constraint(equalTo: content.leadingAnchor),
+            contentStack.trailingAnchor.constraint(equalTo: content.trailingAnchor),
+            contentStack.bottomAnchor.constraint(equalTo: content.bottomAnchor),
+            contentStack.widthAnchor.constraint(equalTo: frame.widthAnchor)
+        ])
+
+        // Without this the scroll view has no intrinsic height in the outer stack,
+        // collapses to 0pt, and clips the content. Hugging the content sizes the card
+        // to fit; below-required priority lets the max-height cap win and scroll.
+        let visibleHeight = frame.heightAnchor.constraint(equalTo: contentStack.heightAnchor)
+        visibleHeight.priority = .defaultHigh
+        visibleHeight.isActive = true
+
+        return scrollView
+    }
+
+    //Buttons stack vertically, each 44pt tall with a hairline above and between
+    //them. A horizontal two-button row can be added later if a popup needs it.
+    private func buildButtons() -> UIView {
+        let container = UIStackView()
+        container.axis = .vertical
+        container.alignment = .fill
+        container.translatesAutoresizingMaskIntoConstraints = false
+
+        container.addArrangedSubview(makeSeparator(vertical: false))
+        for (index, action) in actions.enumerated() {
+            if index > 0 {
+                container.addArrangedSubview(makeSeparator(vertical: false))
+            }
+            container.addArrangedSubview(makeButton(for: action, index: index))
+        }
+        return container
+    }
+
+    //A horizontal row: left-aligned title that expands, switch pinned to the right.
+    private func makeSwitchRow(for spec: SwitchSpec) -> UIView {
+        let row = UIStackView()
+        row.axis = .horizontal
+        row.alignment = .center
+        row.spacing = 8
+
+        let label = UILabel()
+        label.text = spec.title
+        label.font = .systemFont(ofSize: 16)
+        label.numberOfLines = 0
+        label.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        let toggle = UISwitch()
+        toggle.isOn = spec.isOn
+        toggle.onTintColor = spec.color
+        toggle.setContentHuggingPriority(.required, for: .horizontal)
+        // Read the switch off the action's sender rather than capturing `toggle`,
+        // which would retain-cycle the switch with its own action.
+        toggle.addAction(UIAction { action in
+            if let toggle = action.sender as? UISwitch { spec.onChange(toggle.isOn) }
+        }, for: .valueChanged)
+
+        row.addArrangedSubview(label)
+        row.addArrangedSubview(toggle)
+        return row
+    }
+
+    private func makeSectionHeader(_ title: String) -> UILabel {
+        let header = UILabel()
+        header.text = title
+        header.font = .boldSystemFont(ofSize: 17)
+        header.numberOfLines = 0
+        return header
+    }
+
+    private func makeTextFieldRow(for spec: TextFieldSpec) -> UITextField {
+        let field = UITextField()
+        field.text = spec.text
+        field.placeholder = spec.placeholder
+        field.borderStyle = .roundedRect
+        field.font = .systemFont(ofSize: 16)
+        field.heightAnchor.constraint(equalToConstant: 36).isActive = true
+        field.addAction(UIAction { action in
+            if let field = action.sender as? UITextField { spec.onChange(field.text ?? "") }
+        }, for: .editingChanged)
+        return field
+    }
+
+    // The card is vertically centred, so the keyboard would cover the buttons of a
+    // text-field popup (e.g. deploy). Shift the card up by half the keyboard height
+    // while it's shown so it stays centred in the visible area.
+    private func observeKeyboard() {
+        let center = NotificationCenter.default
+        center.addObserver(self, selector: #selector(keyboardWillChange(_:)),
+                           name: UIResponder.keyboardWillShowNotification, object: nil)
+        center.addObserver(self, selector: #selector(keyboardWillHide),
+                           name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+
+    @objc private func keyboardWillChange(_ note: Notification) {
+        guard let frame = note.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else { return }
+        cardCenterY?.constant = -frame.height / 2
+        UIView.animate(withDuration: 0.25) { self.view.layoutIfNeeded() }
+    }
+
+    @objc private func keyboardWillHide() {
+        cardCenterY?.constant = 0
+        UIView.animate(withDuration: 0.25) { self.view.layoutIfNeeded() }
+    }
+
+    private func makeLabel(text: String, font: UIFont) -> UILabel {
+        let label = UILabel()
+        label.text = text
+        label.font = font
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        return label
+    }
+
+    private func makeButton(for action: PopupAction, index: Int) -> UIButton {
+        let button = UIButton(type: .system)
+        button.setTitle(action.title, for: .normal)
+        button.titleLabel?.font = action.style == .cancel
+            ? .boldSystemFont(ofSize: 17)
+            : .systemFont(ofSize: 17)
+        button.setTitleColor(action.style == .destructive ? .systemRed : view.tintColor, for: .normal)
+        button.tag = index
+        button.addTarget(self, action: #selector(actionTapped(_:)), for: .touchUpInside)
+        button.heightAnchor.constraint(equalToConstant: 44).isActive = true
+        return button
+    }
+
+    private func makeSeparator(vertical: Bool) -> UIView {
+        let line = UIView()
+        line.backgroundColor = .separator
+        let thickness = line.dimensionAnchor(vertical: vertical)
+        thickness.constraint(equalToConstant: 0.5).isActive = true
+        return line
+    }
+
+    @objc private func actionTapped(_ sender: UIButton) {
+        let action = actions[sender.tag]
+        dismiss(animated: true) {
+            action.handler?()
+        }
+    }
+}
+
+private extension UIView {
+    //Returns the width anchor for a vertical separator, height anchor otherwise.
+    func dimensionAnchor(vertical: Bool) -> NSLayoutDimension {
+        vertical ? widthAnchor : heightAnchor
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the `UIAlertController`s that floated images and switches onto the alert at hardcoded frames, and the Map filter legend's private `setValue(forKey: "attributedMessage")` KVC hack, with a single reusable Auto-Layout card. These floated/absolute-positioned controls mis-rendered as the system alert metrics changed across iOS versions (the image overlapping the message text, switches drifting off their row, the Done/Back button spilling past

This is a presentation-only re-skin: the scanner alert1–15 decision tree, titles, messages, and actions are preserved verbatim. The backend CloudKit fields are untouched.

## Description

- **New `PopupAlertController`** A centered card with title/message/image, vertically-stacked buttons (normal/cancel/destructive), an optional background tint (the yellow "already exchanged" warning), labeled switch rows, section headers, and a single-line text-field row with keyboard avoidance. Pinned to a light appearance so the card is consistent in any mode and transparent- background images stay visible.
- **Converted scanner alerts** The image alerts (`alert3/4/5/6a/6b/7a/7b`), the warning (`alert13`), Exchange/Collect (`alert3a`/`alert3i`, now a real RGD switch row instead of a switch floating over a button), and Deploy (`alert8`, location text field + Moderator switch; save logic extracted to `saveDeployedLocation()`).
- **Converted the Map filter legend** to six colored switch rows + Active/Inactive section headers; removed the six floated-switch factories and the `attributedMessage` hack.
- **Removed the now-dead** `mismatchSwitch`/`modSwitch` helpers.
- **Navigation bars** Repinned the seven hand-placed `UINavigationBar`s (Tools, Map, Nearest, Active Locations, Location Details, Dosimeters, Photo) leading/trailing to the safe area so the iOS-26 glass Done/Back button no longer spills past the rounded sheet corner.
- **Debug-only `AlertGalleryViewController`** Long-press the version label on the start screen for a tap-through catalog of every pop-up plus layout stress tests, to QA without walking the scan flow. Compiled out of release builds.
- **Tests** Added pop-up unit coverage (button order, background color, light appearance, non-zero content height, switch row, text-field row).

The RGD label from the relabel already on `master` is preserved; the backend `mismatch` key is unchanged.

## Testing

- **Unit suite 77/77, 0 failures** (iPhone 17, iOS 26.0.1), including 10 new pop-up tests.
- **Pending:** on-device visual QA of every pop-up via the Alert Gallery (especially the Deploy keyboard behavior and the Map legend colors).
- **Pending — needs an iPad on iOS 26:** the navigation-bar fix is invisible in iPhone portrait (no horizontal safe-area inset), so the Done/Back button position can only be confirmed on an iPad.

## Reviewer focus

The highest-value check is the **Done/Back button position** at the top of the Tools, Map, and All Locations screens on an iPad running iOS 26, and the pop-up visuals via the Alert Gallery.