### PR TITLE
Stop the Records spinner from animating at rest

### DIFF
--- a/LocationApp/LocationApp/Base.lproj/Main.storyboard
+++ b/LocationApp/LocationApp/Base.lproj/Main.storyboard
@@ -695,7 +695,7 @@
                                     </navigationItem>
                                 </items>
                             </navigationBar>
-                            <activityIndicatorView opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" animating="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="tYh-8K-Cq7">
+                            <activityIndicatorView opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="tYh-8K-Cq7">
                                 <rect key="frame" x="393" y="359" width="20" height="20"/>
                             </activityIndicatorView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="QRCode" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fuk-6e-LJo">

--- a/LocationApp/Utility View/LocationDetails.swift
+++ b/LocationApp/Utility View/LocationDetails.swift
@@ -72,8 +72,12 @@ class LocationDetails: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        
+
+        // The activity indicator only signals an in-progress Edit Record save
+        // (savePopupRecord). Make sure it starts at rest; hidesWhenStopped keeps
+        // it invisible until a save actually runs.
+        activityIndicator.stopAnimating()
+
         if #available(iOS 13.0, *) {
             overrideUserInterfaceStyle = .light
         } else {


### PR DESCRIPTION
- The activity indicator on the Location Details "Records" header only signals an in-progress Edit Record save, but the storyboard had it set to animate on load and nothing ever stopped it, so it spun continuously. Clear the storyboard's animating flag and stop it in viewDidLoad; savePopupRecord still starts and stops it around the actual save, and hidesWhenStopped keeps it invisible the rest of the time.