### PR TITLE
Read modifiedBy username from JAMF managed app config

### DIFF
--- a/LocationApp/Location Cache/Locations.swift
+++ b/LocationApp/Location Cache/Locations.swift
@@ -505,27 +505,11 @@ class LocationsCK : Locations, SettingsService {
         database.add(operation)
     }
     
+    // Reads the field-worker username from the MDM (JAMF) managed app config.
+    // Replaces the deprecated CloudKit user-discovery path (requestApplicationPermission
+    // / discoverUserIdentity); blank on unmanaged devices that carry no MDM payload.
     private func setUser(completionHandler: @escaping (String) -> Void) {
-        DispatchQueue.main.async {
-            CKContainer.default().requestApplicationPermission(.userDiscoverability) { (status, error) in
-                if let error = error {
-                    print(error.localizedDescription)
-                }
-                if status == .granted {
-                        CKContainer.default().fetchUserRecordID { (record, error) in
-                            CKContainer.default().discoverUserIdentity(withUserRecordID: record!, completionHandler: { (userID, error) in
-                                if let givenName = userID?.nameComponents?.givenName, let familyName = userID?.nameComponents?.familyName {
-                                    completionHandler("\(givenName) \(familyName)")
-                                }
-                                else {
-                                    completionHandler(userID?.lookupInfo?.emailAddress ?? "")
-                                }
-                            })
-                        }
-                    }
-                completionHandler("")
-            }
-        }
+        completionHandler(ManagedAppConfig.currentUsername())
     }
     
     private func updateSettings() {

--- a/LocationApp/Location Cache/ManagedAppConfig.swift
+++ b/LocationApp/Location Cache/ManagedAppConfig.swift
@@ -1,0 +1,36 @@
+//
+//  ManagedAppConfig.swift
+//  LocationApp
+//
+//  Created by Daniel Spady on 6/22/26.
+//
+
+import Foundation
+
+/// Reads the field-worker username from the MDM (JAMF) Managed App Configuration
+/// payload. iOS surfaces that payload under a fixed UserDefaults key; values pushed
+/// by JAMF arrive as a dictionary. Returns "" on unmanaged devices (no payload).
+enum ManagedAppConfig {
+
+    /// iOS-defined UserDefaults key holding the MDM-pushed managed configuration.
+    static let managedConfigKey = "com.apple.configuration.managed"
+
+    /// Key inside the managed-config dictionary that holds the worker's name.
+    /// PLACEHOLDER — must match the JAMF payload key SLAC defines for the rollout.
+    /// Examples: "userDisplayName", "username", "fullName", "assignedUser".
+    static let usernameKey = "userDisplayName"
+
+    /// Pure decision: extract the username from a managed-config dictionary.
+    /// Trims whitespace; returns "" when the key is absent, empty, or not a String.
+    static func username(from managedConfig: [String: Any]?) -> String {
+        guard let value = managedConfig?[usernameKey] as? String else {
+            return ""
+        }
+        return value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Reads the live managed configuration from UserDefaults and returns the username.
+    static func currentUsername(defaults: UserDefaults = .standard) -> String {
+        username(from: defaults.dictionary(forKey: managedConfigKey))
+    }
+}

--- a/LocationApp/LocationApp.xcodeproj/project.pbxproj
+++ b/LocationApp/LocationApp.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		84F5ED6721B2024900381E76 /* RecordsUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F5ED6621B2024900381E76 /* RecordsUpdate.swift */; };
 		84F9180222211C9B00D25634 /* NearestDosimeters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F9180122211C9B00D25634 /* NearestDosimeters.swift */; };
 		E404C0C52A124558000D2D14 /* Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = E404C0C32A124558000D2D14 /* Cache.swift */; };
+		DA20260622000000000000D2 /* ManagedAppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA20260622000000000000D1 /* ManagedAppConfig.swift */; };
 		E404C0C62A124558000D2D14 /* Locations.swift in Sources */ = {isa = PBXBuildFile; fileRef = E404C0C42A124558000D2D14 /* Locations.swift */; };
 		E40663E02A1CB77100AA3BC1 /* Groups.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40663DF2A1CB77100AA3BC1 /* Groups.swift */; };
 		E40663E22A1CC2AF00AA3BC1 /* (null) in Sources */ = {isa = PBXBuildFile; };
@@ -145,6 +146,7 @@
 		84F5ED6621B2024900381E76 /* RecordsUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordsUpdate.swift; sourceTree = "<group>"; };
 		84F9180122211C9B00D25634 /* NearestDosimeters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearestDosimeters.swift; sourceTree = "<group>"; };
 		E404C0C32A124558000D2D14 /* Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cache.swift; sourceTree = "<group>"; };
+		DA20260622000000000000D1 /* ManagedAppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedAppConfig.swift; sourceTree = "<group>"; };
 		E404C0C42A124558000D2D14 /* Locations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Locations.swift; sourceTree = "<group>"; };
 		E40663DF2A1CB77100AA3BC1 /* Groups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Groups.swift; sourceTree = "<group>"; };
 		E465C7C52A1CC9E600B7465B /* UpdateGroups.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpdateGroups.swift; sourceTree = "<group>"; };
@@ -184,6 +186,7 @@
 				5A5EFD732A306ED500547EB8 /* Settings.swift */,
 				5A5EFD712A306ED500547EB8 /* SettingsService.swift */,
 				E404C0C32A124558000D2D14 /* Cache.swift */,
+				DA20260622000000000000D1 /* ManagedAppConfig.swift */,
 				E404C0C42A124558000D2D14 /* Locations.swift */,
 				449A7E9C271341B2005AF1F7 /* LocationRecordCacheItem.swift */,
 				E40663DF2A1CB77100AA3BC1 /* Groups.swift */,
@@ -525,6 +528,7 @@
 				E40663E22A1CC2AF00AA3BC1 /* (null) in Sources */,
 				5A5EFD752A306ED500547EB8 /* DIContainer.swift in Sources */,
 				E404C0C52A124558000D2D14 /* Cache.swift in Sources */,
+				DA20260622000000000000D2 /* ManagedAppConfig.swift in Sources */,
 				5CF01FDE22D92F19004604BC /* ToolsViewController.swift in Sources */,
 				DA20260611000000000000A2 /* DeleteOldCyclesViewController.swift in Sources */,
 				84F477962167173A00A63336 /* LocationApp.xcdatamodeld in Sources */,

--- a/LocationApp/LocationAppTests/LocationAppTests.swift
+++ b/LocationApp/LocationAppTests/LocationAppTests.swift
@@ -1148,4 +1148,30 @@ class LocationAppTests: XCTestCase {
         XCTAssertEqual(rgdReported, false, "Flipping RGD should fire its onChange with the new value")
         XCTAssertEqual(moderatorReported, true, "RGD's flip must not disturb the Moderator value")
     }
+
+    // MARK: - ManagedAppConfig (JAMF managed username)
+
+    func test_username_readsConfiguredKey() {
+        let config: [String: Any] = [ManagedAppConfig.usernameKey: "Jane Tech"]
+        XCTAssertEqual(ManagedAppConfig.username(from: config), "Jane Tech")
+    }
+
+    func test_username_trimsWhitespace() {
+        let config: [String: Any] = [ManagedAppConfig.usernameKey: "  Jane Tech \n"]
+        XCTAssertEqual(ManagedAppConfig.username(from: config), "Jane Tech")
+    }
+
+    func test_username_blankWhenPayloadMissing() {
+        XCTAssertEqual(ManagedAppConfig.username(from: nil), "")
+    }
+
+    func test_username_blankWhenKeyAbsent() {
+        let config: [String: Any] = ["someOtherKey": "value"]
+        XCTAssertEqual(ManagedAppConfig.username(from: config), "")
+    }
+
+    func test_username_blankWhenValueNotString() {
+        let config: [String: Any] = [ManagedAppConfig.usernameKey: 42]
+        XCTAssertEqual(ManagedAppConfig.username(from: config), "")
+    }
 }


### PR DESCRIPTION
## Summary

Replaces the deprecated CloudKit user-discovery path with a read of the MDM-pushed **Managed App Configuration**, so `modifiedBy` is populated from Jamf instead of coming back blank.

The old `setUser` called `requestApplicationPermission(.userDiscoverability)` + `discoverUserIdentity` both removed by Apple in iOS 17, which is why `ModifiedBy` has been empty. It also force-unwrapped the user record ID (`discoverUserIdentity(withUserRecordID: record!)`), a latent crash risk.

## Changes

- **New `ManagedAppConfig`** (`Location Cache/ManagedAppConfig.swift`) reads `UserDefaults`' `com.apple.configuration.managed` payload and pulls the worker name. The `username(from:)` decision is pure and unit-tested offline.
- **`Locations.setUser`** now returns `ManagedAppConfig.currentUsername()` no CloudKit round-trip, no force-unwrap. Blank on unmanaged devices.
- The downstream chain is unchanged: `cache.setUser(name:)` to `modifiedBy` to `CKRecord` → CSV export.
- **+5 unit tests** (configured key, whitespace-trim, missing payload, absent key, non-String value).

## ⚠️ Pending dependency — read before testing on device

`ManagedAppConfig.usernameKey` is a **placeholder** (`"userDisplayName"`). It must match the exact key the SLAC Jamf admin defines in the LocationApp managed-config payload. Building before that key is finalized will show a blank name that's the placeholder mismatch, not a regression.

**Device sign-off is gated on:** (1) the Jamf payload key being defined, and (2) an enrolled iPad receiving the payload. Neither can be exercised on a non-managed device.

## Testing

**Unit:** suite green (5 new tests pass offline, no CloudKit/MDM needed).

**On device (non-managed iPhone) — verified:**
- App launches and scans cleanly; no crash (old `record!` unwrap removed).
- Log shows `Cloudkit user:` blank → correct unmanaged fallback.
- New record saves with blank `ModifiedBy`; exported CSV intact.

**On device (enrolled iPad) — pending the Jamf key:**
1. Jamf admin defines the managed app-config payload + username key/value.
2. Update `usernameKey` to match.
3. Build IPA, push via Self Service to the enrolled iPad.
4. Scan a dosimeter to Tools to export CSV.
5. `ModifiedBy` shows the assigned worker's name.