### PR TITLE
View refresh Nearest pull-to-refresh + Map Refresh button

### DIFF
--- a/LocationApp/LocationApp/Base.lproj/Main.storyboard
+++ b/LocationApp/LocationApp/Base.lproj/Main.storyboard
@@ -523,6 +523,11 @@
                                                 <action selector="done:" destination="Pbj-ZR-7ZZ" id="i2U-vc-2yo"/>
                                             </connections>
                                         </barButtonItem>
+                                        <barButtonItem key="rightBarButtonItem" title="Refresh" id="Rf1-bt-n01">
+                                            <connections>
+                                                <action selector="refreshMapFromCloud:" destination="Pbj-ZR-7ZZ" id="Rf2-ac-t02"/>
+                                            </connections>
+                                        </barButtonItem>
                                     </navigationItem>
                                 </items>
                             </navigationBar>

--- a/LocationApp/LocationApp/NearestDosimeters.swift
+++ b/LocationApp/LocationApp/NearestDosimeters.swift
@@ -30,7 +30,7 @@ class NearestLocations: UIViewController, UITableViewDataSource, UITableViewDele
 
     let dispatchGroup = DispatchGroup()
     let recordsupdate = RecordsUpdate()
-    let locations = container.locations
+    var locations: Locations = container.locations
 
     var locationManager:CLLocationManager = CLLocationManager()
     var startLocation: CLLocation!
@@ -78,8 +78,8 @@ class NearestLocations: UIViewController, UITableViewDataSource, UITableViewDele
 
         let refreshControl = UIRefreshControl()
         refreshControl.attributedTitle = NSAttributedString(string: "Pull to Refresh Locations")
-        //this query will populate the tableView when the table is pulled.
-        refreshControl.addTarget(self, action: #selector(queryAscendLocations), for: .valueChanged)
+        //pulling the table syncs from CloudKit first, then repopulates with fresh data.
+        refreshControl.addTarget(self, action: #selector(refreshFromCloud), for: .valueChanged)
         refreshControl.beginRefreshing()
         self.nearestTableView.refreshControl = refreshControl
 
@@ -215,8 +215,19 @@ extension NearestLocations {
             }
         }
     } //end func
-            
-    
+
+    //pull-to-refresh: pull the latest records from CloudKit, then re-filter and reload.
+    //synchronize() no-ops while offline (returns the cached count), so an offline pull still
+    //falls through to queryAscendLocations, which ends refreshing and reloads from the cache.
+    @objc func refreshFromCloud() {
+        DispatchQueue.global(qos: .background).async {
+            self.locations.synchronize(loaded: { _ in
+                self.queryAscendLocations()
+            })
+        }
+    }
+
+
     //to be executed for each fetched record
     func recordFetchedBlock(record: LocationRecordCacheItem) {
         //changed nils in string fields to "".

--- a/LocationApp/LocationAppTests/LocationAppTests.swift
+++ b/LocationApp/LocationAppTests/LocationAppTests.swift
@@ -1174,4 +1174,64 @@ class LocationAppTests: XCTestCase {
         let config: [String: Any] = [ManagedAppConfig.usernameKey: 42]
         XCTAssertEqual(ManagedAppConfig.username(from: config), "")
     }
+
+    // MARK: - Nearest Locations pull-to-refresh (cloud sync)
+
+    // The pull-to-refresh used to only re-filter the local cache, so a technician's
+    // pull never picked up another worker's changes. This verifies the pull now runs
+    // synchronize() (a real CloudKit pull) BEFORE re-filtering the cache.
+
+    func test_pullToRefresh_syncsFromCloudBeforeReFiltering() {
+        let mock = RefreshSpyLocations()
+        let nearest = NearestLocations()
+        nearest.locations = mock
+
+        let refreshed = expectation(description: "re-filter ran after sync")
+        mock.onFilter = { refreshed.fulfill() }
+
+        nearest.refreshFromCloud()
+
+        wait(for: [refreshed], timeout: 2.0)
+        XCTAssertEqual(mock.synchronizeCallCount, 1, "pull must trigger a cloud sync")
+        XCTAssertEqual(mock.filterCallCount, 1, "pull must re-filter after syncing")
+        XCTAssertTrue(mock.syncedBeforeFilter, "sync must run before the re-filter")
+    }
+}
+
+// Minimal Locations test double. Records the order of synchronize()/filter() so the
+// pull-to-refresh test can assert the cloud sync happens before the local re-filter.
+// Every other protocol member is an inert stub; the refresh path never calls them.
+private final class RefreshSpyLocations: Locations {
+    var synchronizeCallCount = 0
+    var filterCallCount = 0
+    var syncedBeforeFilter = false
+    var onFilter: (() -> Void)?
+
+    private var didSync = false
+
+    func synchronize(loaded: @escaping ((Int) -> Void)) {
+        synchronizeCallCount += 1
+        didSync = true
+        loaded(0)   // offline or online, synchronize always reports a count back
+    }
+
+    func filter(by: (LocationRecordCacheItem) -> Bool) -> [LocationRecordCacheItem] {
+        filterCallCount += 1
+        if didSync { syncedBeforeFilter = true }
+        onFilter?()
+        return []
+    }
+
+    func filter(by: @escaping (LocationRecordCacheItem) -> Bool, completionHandler: @escaping ([LocationRecordCacheItem]) -> Void) {
+        completionHandler([])
+    }
+    func groups(completionHandler: @escaping ([String]) -> Void) { completionHandler([]) }
+    func count(by: (LocationRecordCacheItem) -> Bool) -> Int { 0 }
+    func save(item: LocationRecordCacheItem, completionHandler: (() -> Void)?) { completionHandler?() }
+    func save(items: [LocationRecordCacheItem], completionHandler: (() -> Void)?) { completionHandler?() }
+    func reset(_ loaded: @escaping ((Int) -> Void)) { loaded(0) }
+    func fetch(id: String, completionHandler: @escaping (LocationRecordCacheItem?, Error?) -> Void) { completionHandler(nil, nil) }
+    var pendingChangeCount: Int { 0 }
+    func eligibleOldCycleRecords(keepingCycles: Int) -> [LocationRecordCacheItem] { [] }
+    func deleteOldCycleRecords(keepingCycles: Int, progress: @escaping (Int, Int) -> Void, completion: @escaping (Int, Error?) -> Void) { completion(0, nil) }
 }

--- a/LocationApp/LocationAppTests/LocationAppTests.swift
+++ b/LocationApp/LocationAppTests/LocationAppTests.swift
@@ -1196,11 +1196,43 @@ class LocationAppTests: XCTestCase {
         XCTAssertEqual(mock.filterCallCount, 1, "pull must re-filter after syncing")
         XCTAssertTrue(mock.syncedBeforeFilter, "sync must run before the re-filter")
     }
+
+    // MARK: - Map refresh button (cloud sync)
+
+    // The Map only read the local cache (queryForMap), so its pins could be stale
+    // until something else synced. The new Refresh button must run synchronize()
+    // (a real CloudKit pull) BEFORE re-querying the cache to redraw the pins.
+
+    private func loadMapViewController() throws -> MapViewController {
+        let storyboard = UIStoryboard(name: "Main", bundle: Bundle(for: MapViewController.self))
+        let controller = storyboard.instantiateViewController(withIdentifier: "Map")
+        let map = try XCTUnwrap(controller as? MapViewController,
+                                "Main storyboard identifier \"Map\" should resolve to MapViewController")
+        map.loadViewIfNeeded()
+        map.locationmanager.stopUpdatingLocation()
+        return map
+    }
+
+    func test_mapRefresh_syncsFromCloudBeforeReQuerying() throws {
+        let map = try loadMapViewController()
+        let mock = RefreshSpyLocations()
+        map.locations = mock
+
+        let requeried = expectation(description: "re-query ran after sync")
+        mock.onFilter = { requeried.fulfill() }
+
+        map.refreshMapFromCloud(self)
+
+        wait(for: [requeried], timeout: 2.0)
+        XCTAssertEqual(mock.synchronizeCallCount, 1, "refresh must trigger a cloud sync")
+        XCTAssertEqual(mock.filterCallCount, 1, "refresh must re-query the cache after syncing")
+        XCTAssertTrue(mock.syncedBeforeFilter, "sync must run before the re-query")
+    }
 }
 
 // Minimal Locations test double. Records the order of synchronize()/filter() so the
-// pull-to-refresh test can assert the cloud sync happens before the local re-filter.
-// Every other protocol member is an inert stub; the refresh path never calls them.
+// Nearest pull-to-refresh and Map refresh tests can assert the cloud sync happens
+// before the local re-filter. Every other protocol member is an inert stub.
 private final class RefreshSpyLocations: Locations {
     var synchronizeCallCount = 0
     var filterCallCount = 0

--- a/LocationApp/Map/MapViewController.swift
+++ b/LocationApp/Map/MapViewController.swift
@@ -15,7 +15,7 @@ import CloudKit
 
 //MARK:  Class
 class MapViewController: UIViewController {
-    let locations = container.locations
+    var locations: Locations = container.locations
     @IBOutlet weak var MapView: MKMapView!
     @IBOutlet weak var filtersButton: UIButton!
     @IBOutlet weak var activityIndicator: UIActivityIndicatorView!
@@ -69,7 +69,24 @@ class MapViewController: UIViewController {
     @IBAction func done(_ sender: Any) {
         self.dismiss(animated: true, completion: nil)
     }
-	
+
+    //refresh button: pull the latest records from CloudKit, then clear and redraw
+    //the pins. synchronize() no-ops while offline (returns the cached count), so an
+    //offline tap still falls through to a local redraw. addAnnotation must run on main.
+    @IBAction func refreshMapFromCloud(_ sender: Any) {
+        DispatchQueue.main.async {
+            self.activityIndicator.startAnimating()
+        }
+        DispatchQueue.global(qos: .background).async {
+            self.locations.synchronize(loaded: { _ in
+                DispatchQueue.main.async {
+                    self.MapView.removeAnnotations(self.MapView.annotations)
+                    self.queryForMap()
+                }
+            })
+        }
+    }
+
 }
 
 //MapView and locationmanager delegate methods


### PR DESCRIPTION
## Summary

Implements the SOW Revision 2 refresh work: the Nearest Locations list and the Map view now pull fresh data from CloudKit on demand, so field workers see another worker's changes without leaving and re-entering the screen.

Both screens previously only re-read the local cache, so a refresh never reflected changes made elsewhere until a background sync happened to run.

## Changes

**Nearest Locations** (`dbfac0d`)
- Pull-to-refresh now routes through a new `refreshFromCloud()` that runs `synchronize()` (a real CloudKit pull) before re-filtering and reloading the table. Previously the pull only re-sorted the local cache.

**Map** (`f9d98b4`)
- Adds a **Refresh** button to the Map nav bar (opposite Done). It runs `synchronize()`, then clears and redraws the pins from the freshened cache.

**Both**
- Mirror the existing Startup `setProgress()` pattern (background sync, then update the UI on the main thread).
- Offline-safe: `synchronize()` no-ops when there's no connection and falls through to a local redraw — no hang, no crash.

## Tests

- `test_pullToRefresh_syncsFromCloudBeforeReFiltering` — Nearest pull syncs before re-filtering.
- `test_mapRefresh_syncsFromCloudBeforeReQuerying` — Map Refresh syncs before re-querying.
- Both use a shared `RefreshSpyLocations` double that records call order.

## Manual test

1. Open Nearest (or Map) on one device.
2. On a second device — or the CloudKit Dashboard (bump `modifiedDate` so the incremental sync picks it up) — deploy/collect a dosimeter.
3. Pull-to-refresh on Nearest / tap **Refresh** on Map → the change appears.
4. Airplane Mode → refresh still redraws from the local cache, no crash.