### PR TITLE
BUG-001 System dates export blank; BUG-002 missing email-sent sound on iOS 26

### DIFF
--- a/LocationApp/Location Cache/Locations.swift
+++ b/LocationApp/Location Cache/Locations.swift
@@ -219,6 +219,14 @@ class LocationsCK : Locations, SettingsService {
         return cachedCycle == item.cycleDate
     }
 
+    // Copies the server-assigned system dates onto a cached item after a successful
+    // upload, so a device-created record shows its System dates without a Reset Cache.
+    // Pure/internal so tests can drive it (CKRecord.creationDate can't be set offline).
+    internal static func applyServerDates(creationDate: Date?, modificationDate: Date?, to item: LocationRecordCacheItem) {
+        item.creationDate = creationDate
+        item.modificationDate = modificationDate
+    }
+
     //MARK:  Super-user delete
 
     // A record may be deleted only when its cycleDate is NOT among the
@@ -373,8 +381,17 @@ class LocationsCK : Locations, SettingsService {
             let operation = CKModifyRecordsOperation(recordsToSave: recordsToSave, recordIDsToDelete: nil)
             operation.savePolicy = .ifServerRecordUnchanged
             operation.qualityOfService = .userInitiated
+            // The server stamps creationDate/modificationDate (the export's System_Date
+            // columns) on save. Collect the saved records so the cache can pick up those
+            // server dates below, instead of staying nil until a Reset Cache.
+            var savedServerRecords: [CKRecord] = []
             operation.perRecordSaveBlock = { id, result in
-                if case .failure(let error) = result {
+                switch result {
+                case .success(let savedRecord):
+                    // Per-record blocks fire serially on the operation's queue and the
+                    // array is only read after waitUntilFinished, so no lock is needed.
+                    savedServerRecords.append(savedRecord)
+                case .failure(let error):
                     print("Per-record save failed for \(id.recordName): \(error.localizedDescription)")
                 }
             }
@@ -386,6 +403,17 @@ class LocationsCK : Locations, SettingsService {
             }
             self.database.add(operation)
             operation.waitUntilFinished()
+
+            // Backfill the server-assigned System dates onto the cached item, on the
+            // saveChanges thread (holding the cache semaphore) after the op finished —
+            // never from the callback. saveChanges() then persists via cache.save().
+            for savedRecord in savedServerRecords {
+                if let cached = self.cache?.location(forRecordName: savedRecord.recordID.recordName) {
+                    LocationsCK.applyServerDates(creationDate: savedRecord.creationDate,
+                                                 modificationDate: savedRecord.modificationDate,
+                                                 to: cached)
+                }
+            }
         }
     }
     

--- a/LocationApp/LocationAppTests/LocationAppTests.swift
+++ b/LocationApp/LocationAppTests/LocationAppTests.swift
@@ -707,6 +707,29 @@ class LocationAppTests: XCTestCase {
         XCTAssertEqual(cells[10], "06/10/2026", "System collected date must still render when present")
     }
 
+    // MARK: - New records carry their System dates after upload
+
+    // uploadChanges copies a saved record's server dates onto the cached item so a
+    // device-created record's System_Date columns populate without a Reset Cache.
+    // CKRecord.creationDate can't be set offline, so the test passes them directly.
+    func test_applyServerDates_populatesSystemDatesOnNewlyCreatedRecord() throws {
+        let item = try makeItem(recordName: "fresh-record")
+        XCTAssertNil(item.creationDate, "Precondition: a device-authored record has no server creation date yet")
+        XCTAssertNil(item.modificationDate, "Precondition: a device-authored record has no server modification date yet")
+
+        let deployed = try XCTUnwrap(noonLocal(year: 2026, month: 6, day: 24))
+        let collected = try XCTUnwrap(noonLocal(year: 2026, month: 7, day: 1))
+        LocationsCK.applyServerDates(creationDate: deployed, modificationDate: collected, to: item)
+
+        XCTAssertEqual(item.creationDate, deployed)
+        XCTAssertEqual(item.modificationDate, collected)
+
+        // Full circle: the two System_Date columns (9, 10) now render instead of blank.
+        let cells = CycleCSVExport.row(for: item).components(separatedBy: ",")
+        XCTAssertEqual(cells[9], "06/24/2026", "System deploy date must populate after upload, no Reset Cache needed")
+        XCTAssertEqual(cells[10], "07/01/2026", "System collected date must populate after upload, no Reset Cache needed")
+    }
+
     /// Noon local time avoids DST-edge surprises when the exporter formats
     /// the date back in the current calendar.
     private func noonLocal(year: Int, month: Int, day: Int) -> Date? {

--- a/LocationApp/Utility View/DeleteOldCyclesViewController.swift
+++ b/LocationApp/Utility View/DeleteOldCyclesViewController.swift
@@ -8,6 +8,7 @@
 import Foundation
 import UIKit
 import MessageUI
+import AVFoundation
 
 //MARK:  Class
 
@@ -269,7 +270,11 @@ extension DeleteOldCyclesViewController: MFMailComposeViewControllerDelegate {
         switch result {
         case .sent:
             hasEmailedExport = true
-            //MFMailComposeViewController already plays the sent sound itself; don't double it.
+            //Play the "sent" sound only on iOS 26+: the redesigned Mail sheet no
+            //longer plays its own there, while older iOS does (gating avoids a double).
+            if #available(iOS 26.0, *) {
+                AudioServicesPlaySystemSound(1001)
+            }
             print("Delete Old Cycles: all-cycles export emailed (\(exportedRecordCount) records)")
             tableView.reloadData()
         case .failed:

--- a/LocationApp/Utility View/ToolsViewController.swift
+++ b/LocationApp/Utility View/ToolsViewController.swift
@@ -9,6 +9,7 @@
 import Foundation
 import UIKit
 import MessageUI
+import AVFoundation
 //MARK:  Class
 class ToolsViewController: UIViewController, MFMailComposeViewControllerDelegate {
     
@@ -221,7 +222,12 @@ class ToolsViewController: UIViewController, MFMailComposeViewControllerDelegate
     
     
     func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
-        //MFMailComposeViewController already plays the sent sound itself; don't double it.
+        //Play the "sent" sound only on iOS 26+: the redesigned Mail sheet no longer
+        //plays its own there, while older iOS still does (adding ours would double).
+        //Only on an actual send, not cancel/draft.
+        if result == .sent, #available(iOS 26.0, *) {
+            AudioServicesPlaySystemSound(1001)
+        }
         controller.dismiss(animated: true)
     } //end func mailComposeController
     


### PR DESCRIPTION
Fixes two field-reported bugs (both authorized by Ryan). The two changes touch
  disjoint files and are committed together.

  ## BUG-001 — System_Date columns export blank for device-authored records

  Records created on-device exported blank `System_Date` columns because the
  cache's `creationDate`/`modificationDate` stay nil until the next Reset Cache —
  the server stamps those dates on save, but the cache never picked them back up.

  `uploadChanges` now collects the saved `CKRecord`s from `perRecordSaveBlock` and,
  after the `CKModifyRecordsOperation` finishes, backfills the server-assigned
  dates onto each cached item via a new `applyServerDates` helper. This runs on the
  `saveChanges` thread under the cache semaphore (never from the per-record
  callback), and `saveChanges()` then persists them. The export now populates
  without requiring a Reset Cache.

  ## BUG-002 — No "sent" sound on email send (iOS 26)

  The redesigned iOS 26 Mail sheet no longer plays its own "sent" sound, so the
  woosh was missing on email send. We now play `AudioServicesPlaySystemSound(1001)`
  on `.sent`, gated to iOS 26+ so older iOS (which still plays its own) doesn't
  double up. Applied in both `ToolsViewController` and
  `DeleteOldCyclesViewController` mail delegates.

  ## Tests

  Adds a unit test that `applyServerDates` populates the two `System_Date` export
  columns on a freshly created record (CKRecord's creation date can't be set
  offline, so the dates are passed directly).

  ## Notes / verification
  - Rebased onto latest `master` (picks up the deployment-instructions.md commits).
  - The iOS 26.0 threshold for the sound gate is inferred — worth confirming against
    the field-device OS version during the on-device single-woosh check.
  - Device verification pending: confirm a device-created record's System dates
    populate after upload (no Reset Cache), and a single woosh on email send.