### PR TITLE
Prune server-deleted records on completed full reconcile

### DIFF
--- a/LocationApp/Location Cache/Locations.swift
+++ b/LocationApp/Location Cache/Locations.swift
@@ -49,6 +49,10 @@ class LocationsCK : Locations, SettingsService {
     // True while the in-flight query is a full re-download; queryCompletionHandler
     // stamps cache.lastFullReconcile only when that query completes.
     private var fullReconcileInFlight = false
+    // Every recordName the in-flight full re-download has returned so far,
+    // accumulated across cursor pages. Once the download completes, any cached
+    // record NOT in this set was deleted server-side and gets pruned.
+    private var fullReconcileSeenNames = Set<String>()
 
     init() {
         reachability.whenReachable = reachable
@@ -97,6 +101,9 @@ class LocationsCK : Locations, SettingsService {
                 isFullDownload = false
             }
             self.fullReconcileInFlight = isFullDownload
+            if isFullDownload {
+                self.fullReconcileSeenNames.removeAll()
+            }
 
             print(isFullDownload ? "Location query started (full reconcile)" : "Location query started")
             self.query(predicate: predicate, sortDescriptors: [], pageSize: 50, loaded:{
@@ -308,6 +315,24 @@ class LocationsCK : Locations, SettingsService {
         guard pendingChangeCount == 0 else { return false }
         guard let lastReconcile = lastReconcile else { return true }
         return now.timeIntervalSince(lastReconcile) > 24 * 60 * 60
+    }
+
+    // After a COMPLETED full re-download, prune cached records the server did
+    // not return (deleted server-side) — but never queued uploads, stranded
+    // records, recordName-less legacy items, or anything on an empty result.
+    internal static func namesToPruneAfterReconcile(locations: [LocationRecordCacheItem],
+                                                    serverNames: Set<String>,
+                                                    queuedNames: Set<String>) -> Set<String> {
+        guard !serverNames.isEmpty else { return [] }
+        var result = Set<String>()
+        for item in locations {
+            guard let name = item.recordName else { continue }
+            if serverNames.contains(name) { continue }
+            if queuedNames.contains(name) { continue }
+            if isRecoveryCandidate(item: item) { continue }
+            result.insert(name)
+        }
+        return result
     }
 
     // Caller must hold the semaphore. Appends directly rather than through
@@ -562,12 +587,18 @@ class LocationsCK : Locations, SettingsService {
             // A failed full download proves nothing; leave the reconcile
             // timestamp unstamped so the next sync tries again.
             fullReconcileInFlight = false
+            fullReconcileSeenNames.removeAll()
             loaded(cache!.locations.count)
             return
         }
-        
+
         if (!records.isEmpty){
             for record in records {
+                // Track by raw recordID, not the converted item: a record that
+                // fails conversion is still on the server and must not be pruned.
+                if fullReconcileInFlight, let record = record as? CKRecord {
+                    fullReconcileSeenNames.insert(record.recordID.recordName)
+                }
                 if let item = LocationRecordCacheItem(withRecord: record as! CKRecord) {
                     cache!.add(item)
                 }
@@ -577,15 +608,24 @@ class LocationsCK : Locations, SettingsService {
             }
             print("Cache new records: \(records.count)")
         }
-        
+
         if let completed = completed {
             if completed {
                 print("Location query completed.")
                 // A completed full download refreshed every record — restart
                 // the 24h reconcile clock. Runs under the sync's semaphore.
                 if fullReconcileInFlight {
+                    let queuedNames = Set(cache!.changes.compactMap { $0.recordName })
+                    let pruned = LocationsCK.namesToPruneAfterReconcile(locations: cache!.locations,
+                                                                        serverNames: fullReconcileSeenNames,
+                                                                        queuedNames: queuedNames)
+                    if !pruned.isEmpty {
+                        let removed = cache!.remove(recordNames: pruned)
+                        print("Full reconcile: pruned \(removed) server-deleted records")
+                    }
                     cache!.lastFullReconcile = Date()
                     fullReconcileInFlight = false
+                    fullReconcileSeenNames.removeAll()
                 }
                 cache!.save()
                 loaded(cache!.locations.count)

--- a/LocationApp/LocationApp.xcodeproj/project.pbxproj
+++ b/LocationApp/LocationApp.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		DAB000000000000000000B /* PopupAlertTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF000000000000000000B /* PopupAlertTests.swift */; };
 		DAB000000000000000000C /* ManagedAppConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF000000000000000000C /* ManagedAppConfigTests.swift */; };
 		DAB000000000000000000D /* RefreshFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF000000000000000000D /* RefreshFlowTests.swift */; };
+		DAB000000000000000000E /* ReconcilePruneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF000000000000000000E /* ReconcilePruneTests.swift */; };
 		8421B0842165BBB90041A53A /* LocationAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8421B0832165BBB90041A53A /* LocationAppUITests.swift */; };
 		8434D57B25956DE800B2E413 /* RepairCycleDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8434D57A25956DE800B2E413 /* RepairCycleDate.swift */; };
 		8434D58025957C9300B2E413 /* Data_File.csv in Resources */ = {isa = PBXBuildFile; fileRef = 8434D57F25957C9300B2E413 /* Data_File.csv */; };
@@ -136,6 +137,7 @@
 		DAF000000000000000000B /* PopupAlertTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupAlertTests.swift; sourceTree = "<group>"; };
 		DAF000000000000000000C /* ManagedAppConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedAppConfigTests.swift; sourceTree = "<group>"; };
 		DAF000000000000000000D /* RefreshFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshFlowTests.swift; sourceTree = "<group>"; };
+		DAF000000000000000000E /* ReconcilePruneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconcilePruneTests.swift; sourceTree = "<group>"; };
 		8421B07A2165BBB90041A53A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8421B07F2165BBB90041A53A /* LocationAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LocationAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8421B0832165BBB90041A53A /* LocationAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationAppUITests.swift; sourceTree = "<group>"; };
@@ -302,6 +304,7 @@
 				DAF000000000000000000B /* PopupAlertTests.swift */,
 				DAF000000000000000000C /* ManagedAppConfigTests.swift */,
 				DAF000000000000000000D /* RefreshFlowTests.swift */,
+				DAF000000000000000000E /* ReconcilePruneTests.swift */,
 				8421B07A2165BBB90041A53A /* Info.plist */,
 			);
 			path = LocationAppTests;
@@ -623,6 +626,7 @@
 				DAB000000000000000000B /* PopupAlertTests.swift in Sources */,
 				DAB000000000000000000C /* ManagedAppConfigTests.swift in Sources */,
 				DAB000000000000000000D /* RefreshFlowTests.swift in Sources */,
+				DAB000000000000000000E /* ReconcilePruneTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LocationApp/LocationAppTests/ReconcilePruneTests.swift
+++ b/LocationApp/LocationAppTests/ReconcilePruneTests.swift
@@ -1,0 +1,147 @@
+//
+//  ReconcilePruneTests.swift
+//  LocationAppTests
+//
+//  Created by Daniel Spady on 7/23/26.
+//
+
+import XCTest
+import CloudKit
+@testable import LocationApp
+
+class ReconcilePruneTests: XCTestCase {
+
+    // MARK: - Prune decision after a completed full reconcile
+
+    // A completed full re-download returned every record the server has. A cached
+    // record missing from that set was deleted server-side (dashboard cleanup)
+    // and must be pruned — unless it still holds unconfirmed local work.
+
+    func test_prune_serverDeletedRecord_selected() throws {
+        let ghost = try makeItem(recordName: "GHOST", creationDate: 1_000, modificationDate: 1_000)
+
+        let pruned = LocationsCK.namesToPruneAfterReconcile(locations: [ghost],
+                                                            serverNames: ["OTHER"],
+                                                            queuedNames: [])
+
+        XCTAssertEqual(pruned, ["GHOST"],
+                       "a server-stamped record the full download no longer returns is a ghost")
+    }
+
+    func test_prune_serverReturnedRecord_kept() throws {
+        let alive = try makeItem(recordName: "R1", creationDate: 1_000, modificationDate: 1_000)
+
+        let pruned = LocationsCK.namesToPruneAfterReconcile(locations: [alive],
+                                                            serverNames: ["R1"],
+                                                            queuedNames: [])
+
+        XCTAssertTrue(pruned.isEmpty, "a record the server still returns is never pruned")
+    }
+
+    func test_prune_queuedEdit_kept() throws {
+        // A record with a queued (not yet confirmed) upload must survive even if
+        // the server doesn't return it — pruning it would discard a tech's work.
+        let edited = try makeItem(recordName: "QUEUED", creationDate: 1_000, modificationDate: 1_000)
+
+        let pruned = LocationsCK.namesToPruneAfterReconcile(locations: [edited],
+                                                            serverNames: ["OTHER"],
+                                                            queuedNames: ["QUEUED"])
+
+        XCTAssertTrue(pruned.isEmpty, "a queued upload must never be pruned out from under the queue")
+    }
+
+    func test_prune_strandedRecord_kept() throws {
+        // No server System dates = authored here, never confirmed uploaded. The
+        // server not returning it is expected, not evidence of deletion.
+        let stranded = try makeItem(recordName: "STRANDED", cycleDate: "7-1-2026")
+
+        let pruned = LocationsCK.namesToPruneAfterReconcile(locations: [stranded],
+                                                            serverNames: ["OTHER"],
+                                                            queuedNames: [])
+
+        XCTAssertTrue(pruned.isEmpty, "a stranded scan belongs to recovery, not the pruner")
+    }
+
+    func test_prune_legacyNilRecordName_kept() throws {
+        let orphan = try makeItem(recordName: nil)
+
+        let pruned = LocationsCK.namesToPruneAfterReconcile(locations: [orphan],
+                                                            serverNames: ["OTHER"],
+                                                            queuedNames: [])
+
+        XCTAssertTrue(pruned.isEmpty, "an item without a recordName can't be matched against the server")
+    }
+
+    func test_prune_emptyServerResult_prunesNothing() throws {
+        // Safety valve: a full download that "completes" with zero records is far
+        // more likely a malfunction than a real database wipe — never prune on it.
+        let synced = try makeItem(recordName: "R1", creationDate: 1_000, modificationDate: 1_000)
+
+        let pruned = LocationsCK.namesToPruneAfterReconcile(locations: [synced],
+                                                            serverNames: [],
+                                                            queuedNames: [])
+
+        XCTAssertTrue(pruned.isEmpty, "an empty server result must never empty the cache")
+    }
+
+    func test_prune_mixedCache_selectsExactlyTheGhosts() throws {
+        let alive = try makeItem(recordName: "ALIVE", creationDate: 1_000, modificationDate: 1_000)
+        let ghost1 = try makeItem(recordName: "GHOST-1", creationDate: 1_000, modificationDate: 1_000)
+        let ghost2 = try makeItem(recordName: "GHOST-2", creationDate: 2_000, modificationDate: 2_000)
+        let queued = try makeItem(recordName: "QUEUED", creationDate: 1_000, modificationDate: 1_000)
+        let stranded = try makeItem(recordName: "STRANDED")
+        let orphan = try makeItem(recordName: nil)
+
+        let pruned = LocationsCK.namesToPruneAfterReconcile(locations: [alive, ghost1, ghost2, queued, stranded, orphan],
+                                                            serverNames: ["ALIVE"],
+                                                            queuedNames: ["QUEUED"])
+
+        XCTAssertEqual(pruned, ["GHOST-1", "GHOST-2"],
+                       "exactly the server-deleted records are selected, nothing protected")
+    }
+
+    // MARK: - Applying the prune to the cache
+
+    func test_cacheRemove_clearsRecordAndLookup() throws {
+        let cache = Cache()
+        cache.add(try makeItem(recordName: "GHOST", creationDate: 1_000, modificationDate: 1_000))
+        cache.add(try makeItem(recordName: "ALIVE", creationDate: 1_000, modificationDate: 1_000))
+
+        let removed = cache.remove(recordNames: ["GHOST"])
+
+        XCTAssertEqual(removed, 1)
+        XCTAssertNil(cache.location(forRecordName: "GHOST"), "the ghost is gone from the lookup index")
+        XCTAssertNotNil(cache.location(forRecordName: "ALIVE"),
+                        "the index still resolves surviving records after the rebuild")
+        XCTAssertEqual(cache.locations.map { $0.recordName }, ["ALIVE"])
+    }
+
+    // MARK: - Acceptance: the dashboard-delete case
+
+    // A record deleted on the CloudKit dashboard lingers on every device that
+    // already downloaded it, because incremental sync only adds and updates.
+    // The daily full reconcile must drop it without touching pending scans.
+    func test_acceptance_dashboardDelete_propagatesOnDailyReconcile() throws {
+        let cache = Cache()
+        for i in 1...4 {
+            cache.add(try makeItem(recordName: "R\(i)", creationDate: 1_000, modificationDate: 1_000))
+        }
+        cache.add(try makeItem(recordName: "DELETED-ON-DASHBOARD", creationDate: 1_000, modificationDate: 1_000))
+        let pendingCollect = try makeItem(recordName: "PENDING-COLLECT", cycleDate: "7-1-2026")
+        pendingCollect.collectedFlag = 1
+        cache.add(pendingCollect)
+
+        // the completed full download returns everything the server still has
+        let serverNames: Set<String> = ["R1", "R2", "R3", "R4"]
+        let queuedNames = Set(cache.changes.compactMap { $0.recordName })
+        let pruned = LocationsCK.namesToPruneAfterReconcile(locations: cache.locations,
+                                                            serverNames: serverNames,
+                                                            queuedNames: queuedNames)
+        cache.remove(recordNames: pruned)
+
+        XCTAssertEqual(pruned, ["DELETED-ON-DASHBOARD"], "the dashboard delete reaches the device")
+        XCTAssertNotNil(cache.location(forRecordName: "PENDING-COLLECT"),
+                        "the unuploaded scan survives the same reconcile")
+        XCTAssertEqual(cache.locations.count, 5)
+    }
+}


### PR DESCRIPTION
## Problem

Incremental sync only adds and updates. It never removes. A record deleted in CloudKit (e.g. via dashboard cleanup) therefore lived on indefinitely in every device cache that had already downloaded it, showing up in All Locations, Map,
and Nearest views until that device did a manual Reset Cache.

## Fix

The daily full re-download now doubles as a deletion sweep (`da00dc2`):

- While a full reconcile is in flight, `LocationsCK` accumulates every recordName the server returns across all cursor pages. Names are taken from the raw `recordID`, so a record that fails cache conversion still counts as alive and can never be pruned by mistake.
- When the download **completes**, cached records the server no longer returned are removed via the pure helper `namesToPruneAfterReconcile` and `Cache.remove(recordNames:)`, which also drops them from the pending-changes queue and rebuilds the lookup index.

## Safety guards

- **Queued uploads** and **stranded records** (no server System dates, scans still waiting to upload) are never pruned, so unconfirmed field work cannot be discarded.
- **recordName-less legacy items** can't be matched against the server and are left alone.
- **An empty server result prunes nothing** — a zero-record "success" is treated as a query malfunction, not a database wipe.
- **A failed or partial download prunes nothing** and leaves the 24h reconcile clock unstamped so the next sync retries.
- Incremental syncs are completely unaffected; everything runs under the existing sync semaphore.

## Tests

9 new tests in `ReconcilePruneTests.swift`: one per guard, the empty-result valve, cache removal/index rebuild, and an acceptance case showing a dashboard-deleted record disappearing while a pending collect survives the same reconcile. Full suite: **134/134 passing**.

## Rollout note

The first full reconcile after this build installs will clear any ghosts a device has accumulated to date, so dosimeter counts may visibly drop once. That's the accumulated server-side deletions finally propagating, not data loss. Deployed/pending records are untouched.